### PR TITLE
Run `glove-100-angular` on AWS - both compressed and uncompressed

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: preview-pq-with-rescoring-5694ad2
+  WEAVIATE_VERSION: preview-pq-with-rescoring-fe3af80
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
 on:
   push
@@ -139,6 +139,10 @@ jobs:
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
     runs-on: ubuntu-latest
+    env:
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.999
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -164,6 +168,10 @@ jobs:
   ann-benchmarks-pq-sift-gcp:
     name: "[bench GCP] SIFT1M pq=true"
     runs-on: ubuntu-latest
+    env:
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.992
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,12 @@ jobs:
   ann-benchmarks-sift-aws:
     name: "[ANN-Benchmarks][AWS] SIFT1M pq=false"
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.999
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -30,7 +36,7 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: Run chaos test
-        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} DATASET=sift-128-euclidean DISTANCE=l2-squared ./ann_benchmark_aws.sh
+        run: ./ann_benchmark_aws.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -40,6 +46,12 @@ jobs:
   ann-benchmarks-glove-aws:
     name: "[ANN-Benchmarks][AWS] Glove100 pq=false"
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: glove-100-recall
+      DISTANCE: cosine
+      REQUIRED_RECALL: 0.965
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -55,7 +67,7 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: Run chaos test
-        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} DATASET=glove-100-angular DISTANCE=cosine ./ann_benchmark_aws.sh
+        run: ./ann_benchmark_aws.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -113,7 +113,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
       DATASET: glove-100-angular
       DISTANCE: cosine
-      REQUIRED_RECALL: 0.965
+      REQUIRED_RECALL: 0.91
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,7 +49,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: glove-100-recall
+      DATASET: glove-100-angular
       DISTANCE: cosine
       REQUIRED_RECALL: 0.965
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -194,364 +194,364 @@ jobs:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
-  # batch-import-many-classes:
-  #   name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+  batch-import-many-classes:
+    name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./batch_import_many_classes.sh
+  upgrade-journey:
+    name: Rolling updates in multi-node setup from min to target version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./upgrade_journey.sh
+  replicated-imports-with-choas-killing:
+    name: Replicated imports with chaos killing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./replication_importing_while_crashing.sh
+  replication-tunable-consistency:
+    name: Replication tunable consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./replication_tunable_consistency.sh
+  counting-while-compacting:
+    name: Counting while compacting
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./counting_while_compacting.sh
+  segfault-on-batch-ref:
+    name: Segfault on batch ref
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./segfault_batch_ref.sh
+  import-with-kills:
+    name: Import during constant kills/crashes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./import_while_crashing.sh
+  heave-imports-crashing:
+    name: Heavy object store imports while crashing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./import_while_crashing_no_vector.sh
+  segfault-filtered-search:
+    name: Segfault on filtered vector search (race with hash bucket compaction)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./segfault_filtered_vector_search.sh
+  backup-restore-crud:
+    name: Backup & Restore CRUD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_crud.sh
+  backup-restore-crud-multi-node:
+    name: Backup & Restore multi node CRUD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_multi_node_crud.sh
+  backup-restore-version-compat:
+    name: Backup & Restore version compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_version_compatibility.sh
+  compare-recall:
+    name: Compare Recall after import to after restart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./compare_recall_after_restart.sh
+  concurrent-read-write:
+    name: Concurrent inverted index read/write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./concurrent_inverted_index_read_write.sh
+  consecutive-create-update:
+    name: Consecutive create and update operations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./consecutive_create_and_update_operations.sh
+  batch-insert-missmatch:
+    name: Batch insert mismatch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./consecutive_create_and_update_operations.sh
+  rest-patch-restart:
+    name: REST PATCH requests stop working after restart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./rest_patch_stops_working_after_restart.sh
+  delete-recreate-updates:
+    name: Delete and recreate class with frequent updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./delete_and_recreate_class.sh
+  geo-crash:
+    name: Preventing crashing of geo properties during HNSW maintenance cycles
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./geo_crash.sh
+  compaction-roaringset:
+    name: Preventing panic on compaction of roaringsets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./compaction_roaringset.sh
+  # Commented only because this chaos pipeline was able to interrupt save operation
+  # just in the middle of it being performed and since Weaviate doesn't have a transaction
+  # mechanism implemented then this was causing an error which is a different error then
+  # the discrepancy one, but this pipeline is really good in crashing Weaviate so we want to
+  # save it for future tests
+  # compare-while-crashing:
+  #   name: Compare REST and GraphQL while crashing
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
   #     - name: Login to Docker Hub
   #       uses: docker/login-action@v2
   #       with:
   #         username: ${{secrets.DOCKER_USERNAME}}
   #         password: ${{secrets.DOCKER_PASSWORD}}
   #     - name: Run chaos test
-  #       run: ./batch_import_many_classes.sh
-  # upgrade-journey:
-  #   name: Rolling updates in multi-node setup from min to target version
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: '1.20'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./upgrade_journey.sh
-  # replicated-imports-with-choas-killing:
-  #   name: Replicated imports with chaos killing
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./replication_importing_while_crashing.sh
-  # replication-tunable-consistency:
-  #   name: Replication tunable consistency
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./replication_tunable_consistency.sh
-  # counting-while-compacting:
-  #   name: Counting while compacting
-  #   runs-on: ubuntu-latest-8-cores
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./counting_while_compacting.sh
-  # segfault-on-batch-ref:
-  #   name: Segfault on batch ref
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./segfault_batch_ref.sh
-  # import-with-kills:
-  #   name: Import during constant kills/crashes
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./import_while_crashing.sh
-  # heave-imports-crashing:
-  #   name: Heavy object store imports while crashing
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./import_while_crashing_no_vector.sh
-  # segfault-filtered-search:
-  #   name: Segfault on filtered vector search (race with hash bucket compaction)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./segfault_filtered_vector_search.sh
-  # backup-restore-crud:
-  #   name: Backup & Restore CRUD
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_crud.sh
-  # backup-restore-crud-multi-node:
-  #   name: Backup & Restore multi node CRUD
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_multi_node_crud.sh
-  # backup-restore-version-compat:
-  #   name: Backup & Restore version compatibility
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_version_compatibility.sh
-  # compare-recall:
-  #   name: Compare Recall after import to after restart
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./compare_recall_after_restart.sh
-  # concurrent-read-write:
-  #   name: Concurrent inverted index read/write
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./concurrent_inverted_index_read_write.sh
-  # consecutive-create-update:
-  #   name: Consecutive create and update operations
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./consecutive_create_and_update_operations.sh
-  # batch-insert-missmatch:
-  #   name: Batch insert mismatch
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./consecutive_create_and_update_operations.sh
-  # rest-patch-restart:
-  #   name: REST PATCH requests stop working after restart
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./rest_patch_stops_working_after_restart.sh
-  # delete-recreate-updates:
-  #   name: Delete and recreate class with frequent updates
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./delete_and_recreate_class.sh
-  # geo-crash:
-  #   name: Preventing crashing of geo properties during HNSW maintenance cycles
-  #   runs-on: ubuntu-latest-8-cores
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./geo_crash.sh
-  # compaction-roaringset:
-  #   name: Preventing panic on compaction of roaringsets
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./compaction_roaringset.sh
-  # # Commented only because this chaos pipeline was able to interrupt save operation
-  # # just in the middle of it being performed and since Weaviate doesn't have a transaction
-  # # mechanism implemented then this was causing an error which is a different error then
-  # # the discrepancy one, but this pipeline is really good in crashing Weaviate so we want to
-  # # save it for future tests
-  # # compare-while-crashing:
-  # #   name: Compare REST and GraphQL while crashing
-  # #   runs-on: ubuntu-latest
-  # #   steps:
-  # #     - uses: actions/checkout@v3
-  # #     - name: Login to Docker Hub
-  # #       uses: docker/login-action@v2
-  # #       with:
-  # #         username: ${{secrets.DOCKER_USERNAME}}
-  # #         password: ${{secrets.DOCKER_PASSWORD}}
-  # #     - name: Run chaos test
-  # #       run: ./compare_rest_graphql_while_crashing.sh
+  #       run: ./compare_rest_graphql_while_crashing.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,7 +30,32 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: Run chaos test
-        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} ./ann_benchmark_aws.sh
+        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} DATASET=sift-128-euclidean DISTANCE=l2-squared ./ann_benchmark_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-glove-aws:
+    name: "[ANN-Benchmarks][AWS] Glove100 pq=false"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} DATASET=glove-100-angular DISTANCE=cosine ./ann_benchmark_aws.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -149,364 +149,364 @@ jobs:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
-  batch-import-many-classes:
-    name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./batch_import_many_classes.sh
-  upgrade-journey:
-    name: Rolling updates in multi-node setup from min to target version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.20'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./upgrade_journey.sh
-  replicated-imports-with-choas-killing:
-    name: Replicated imports with chaos killing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_importing_while_crashing.sh
-  replication-tunable-consistency:
-    name: Replication tunable consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_tunable_consistency.sh
-  counting-while-compacting:
-    name: Counting while compacting
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./counting_while_compacting.sh
-  segfault-on-batch-ref:
-    name: Segfault on batch ref
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_batch_ref.sh
-  import-with-kills:
-    name: Import during constant kills/crashes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing.sh
-  heave-imports-crashing:
-    name: Heavy object store imports while crashing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing_no_vector.sh
-  segfault-filtered-search:
-    name: Segfault on filtered vector search (race with hash bucket compaction)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_filtered_vector_search.sh
-  backup-restore-crud:
-    name: Backup & Restore CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_crud.sh
-  backup-restore-crud-multi-node:
-    name: Backup & Restore multi node CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_multi_node_crud.sh
-  backup-restore-version-compat:
-    name: Backup & Restore version compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_version_compatibility.sh
-  compare-recall:
-    name: Compare Recall after import to after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compare_recall_after_restart.sh
-  concurrent-read-write:
-    name: Concurrent inverted index read/write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./concurrent_inverted_index_read_write.sh
-  consecutive-create-update:
-    name: Consecutive create and update operations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  batch-insert-missmatch:
-    name: Batch insert mismatch
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  rest-patch-restart:
-    name: REST PATCH requests stop working after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./rest_patch_stops_working_after_restart.sh
-  delete-recreate-updates:
-    name: Delete and recreate class with frequent updates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./delete_and_recreate_class.sh
-  geo-crash:
-    name: Preventing crashing of geo properties during HNSW maintenance cycles
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./geo_crash.sh
-  compaction-roaringset:
-    name: Preventing panic on compaction of roaringsets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compaction_roaringset.sh
-  # Commented only because this chaos pipeline was able to interrupt save operation
-  # just in the middle of it being performed and since Weaviate doesn't have a transaction
-  # mechanism implemented then this was causing an error which is a different error then
-  # the discrepancy one, but this pipeline is really good in crashing Weaviate so we want to
-  # save it for future tests
-  # compare-while-crashing:
-  #   name: Compare REST and GraphQL while crashing
+  # batch-import-many-classes:
+  #   name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
   #     - name: Login to Docker Hub
   #       uses: docker/login-action@v2
   #       with:
   #         username: ${{secrets.DOCKER_USERNAME}}
   #         password: ${{secrets.DOCKER_PASSWORD}}
   #     - name: Run chaos test
-  #       run: ./compare_rest_graphql_while_crashing.sh
+  #       run: ./batch_import_many_classes.sh
+  # upgrade-journey:
+  #   name: Rolling updates in multi-node setup from min to target version
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: '1.20'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./upgrade_journey.sh
+  # replicated-imports-with-choas-killing:
+  #   name: Replicated imports with chaos killing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_importing_while_crashing.sh
+  # replication-tunable-consistency:
+  #   name: Replication tunable consistency
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_tunable_consistency.sh
+  # counting-while-compacting:
+  #   name: Counting while compacting
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./counting_while_compacting.sh
+  # segfault-on-batch-ref:
+  #   name: Segfault on batch ref
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_batch_ref.sh
+  # import-with-kills:
+  #   name: Import during constant kills/crashes
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing.sh
+  # heave-imports-crashing:
+  #   name: Heavy object store imports while crashing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing_no_vector.sh
+  # segfault-filtered-search:
+  #   name: Segfault on filtered vector search (race with hash bucket compaction)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_filtered_vector_search.sh
+  # backup-restore-crud:
+  #   name: Backup & Restore CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_crud.sh
+  # backup-restore-crud-multi-node:
+  #   name: Backup & Restore multi node CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_multi_node_crud.sh
+  # backup-restore-version-compat:
+  #   name: Backup & Restore version compatibility
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_version_compatibility.sh
+  # compare-recall:
+  #   name: Compare Recall after import to after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compare_recall_after_restart.sh
+  # concurrent-read-write:
+  #   name: Concurrent inverted index read/write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./concurrent_inverted_index_read_write.sh
+  # consecutive-create-update:
+  #   name: Consecutive create and update operations
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # batch-insert-missmatch:
+  #   name: Batch insert mismatch
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # rest-patch-restart:
+  #   name: REST PATCH requests stop working after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./rest_patch_stops_working_after_restart.sh
+  # delete-recreate-updates:
+  #   name: Delete and recreate class with frequent updates
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./delete_and_recreate_class.sh
+  # geo-crash:
+  #   name: Preventing crashing of geo properties during HNSW maintenance cycles
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./geo_crash.sh
+  # compaction-roaringset:
+  #   name: Preventing panic on compaction of roaringsets
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compaction_roaringset.sh
+  # # Commented only because this chaos pipeline was able to interrupt save operation
+  # # just in the middle of it being performed and since Weaviate doesn't have a transaction
+  # # mechanism implemented then this was causing an error which is a different error then
+  # # the discrepancy one, but this pipeline is really good in crashing Weaviate so we want to
+  # # save it for future tests
+  # # compare-while-crashing:
+  # #   name: Compare REST and GraphQL while crashing
+  # #   runs-on: ubuntu-latest
+  # #   steps:
+  # #     - uses: actions/checkout@v3
+  # #     - name: Login to Docker Hub
+  # #       uses: docker/login-action@v2
+  # #       with:
+  # #         username: ${{secrets.DOCKER_USERNAME}}
+  # #         password: ${{secrets.DOCKER_PASSWORD}}
+  # #     - name: Run chaos test
+  # #       run: ./compare_rest_graphql_while_crashing.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
   ann-benchmarks-sift-aws:
-    name: "[ANN-Benchmarks][AWS] SIFT1M pq=false"
+    name: "[bench AWS] SIFT1M pq=false"
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
@@ -44,7 +44,7 @@ jobs:
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
   ann-benchmarks-glove-aws:
-    name: "[ANN-Benchmarks][AWS] Glove100 pq=false"
+    name: "[bench AWS] Glove100 pq=false"
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
@@ -75,8 +75,14 @@ jobs:
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
   ann-benchmarks-pq-sift-aws:
-    name: "[ANN-Benchmarks][AWS] SIFT1M pq=true"
+    name: "[bench AWS] SIFT1M pq=true"
     runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.992
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -92,7 +98,38 @@ jobs:
       - name: 'Set up Cloud SDK'
         uses: 'google-github-actions/setup-gcloud@v1'
       - name: Run chaos test
-        run: AWS_ACCESS_KEY_ID=${{secrets.AWS_ACCESS_KEY}} AWS_SECRET_ACCESS_KEY=${{secrets.AWS_SECRET_ACCESS_KEY}} ./ann_benchmark_compression_aws.sh
+        run: ./ann_benchmark_compression_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-pq-glove-aws:
+    name: "[bench AWS] Glove100 pq=true"
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: glove-100-angular
+      DISTANCE: cosine
+      REQUIRED_RECALL: 0.965
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_compression_aws.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -100,7 +137,7 @@ jobs:
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
   ann-benchmarks-sift-gcp:
-    name: "[ANN-Benchmarks][GCP] SIFT1M pq=false"
+    name: "[bench GCP] SIFT1M pq=false"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -125,7 +162,7 @@ jobs:
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
   ann-benchmarks-pq-sift-gcp:
-    name: "[ANN-Benchmarks][GCP] SIFT1M pq=true"
+    name: "[bench GCP] SIFT1M pq=true"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -54,7 +54,10 @@ sleep 30
 echo "Second run (query only)"
 docker run --network host -t -v "$PWD/results:/workdir/results" -v "$PWD/datasets:/datasets" ann_benchmarks python3 run.py -v /datasets/${dataset}.hdf5 -d $distance -m 32 --query-only --labels "pq=false,after_restart=true,weaviate_version=$WEAVIATE_VERSION,cloud_provider=$CLOUD_PROVIDER,machine_type=$MACHINE_TYPE,os=$OS"
 
-docker run --network host -t -v "$PWD/datasets:/datasets" -v "$PWD/results:/workdir/results" ann_benchmarks python3 analyze.py
+docker run --network host -t -v "$PWD/datasets:/datasets" \
+  -v "$PWD/results:/workdir/results" \
+  -e "REQUIRED_RECALL=$REQUIRED_RECALL" \
+  ann_benchmarks python3 analyze.py
 
 
 echo "Passed!"

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -73,7 +73,7 @@ ssh -i "${key_id}.pem" $ssh_addr -- "mkdir -p ~/apps/"
 scp -i "${key_id}.pem" -r apps/ann-benchmarks "$ssh_addr:~/apps/"
 scp -i "${key_id}.pem" -r apps/weaviate-no-restart-on-crash/ "$ssh_addr:~/apps/"
 scp -i "${key_id}.pem" -r ann_benchmark.sh "$ssh_addr:~"
-ssh -i "${key_id}.pem" $ssh_addr -- "DATASET=$dataset DISTANCE=$distance WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
+ssh -i "${key_id}.pem" $ssh_addr -- "DATASET=$dataset DISTANCE=$distance REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
 mkdir -p results
 scp -i "${key_id}.pem" -r "$ssh_addr:~/results/*.json" results/
 

--- a/ann_benchmark_compression_aws.sh
+++ b/ann_benchmark_compression_aws.sh
@@ -6,6 +6,8 @@ MACHINE_TYPE="${MACHINE_TYPE:-"m6i.2xlarge"}"
 CLOUD_PROVIDER="aws"
 OS="ubuntu-2204"
 ARCH=amd64
+dataset=${DATASET:-"sift-128-euclidean"}
+distance=${DISTANCE:-"l2-squared"}
 
 region="eu-central-1"
 
@@ -71,7 +73,7 @@ ssh -i "${key_id}.pem" $ssh_addr -- "mkdir -p ~/apps/"
 scp -i "${key_id}.pem" -r apps/ann-benchmarks "$ssh_addr:~/apps/"
 scp -i "${key_id}.pem" -r apps/weaviate-no-restart-on-crash/ "$ssh_addr:~/apps/"
 scp -i "${key_id}.pem" -r ann_benchmark_compression.sh "$ssh_addr:~"
-ssh -i "${key_id}.pem" $ssh_addr -- "WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_compression.sh"
+ssh -i "${key_id}.pem" $ssh_addr -- "DATASET=$dataset DISTANCE=$distance REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_compression.sh"
 mkdir -p results
 scp -i "${key_id}.pem" -r "$ssh_addr:~/results/*.json" results/
 

--- a/ann_benchmark_compression_gcp.sh
+++ b/ann_benchmark_compression_gcp.sh
@@ -28,7 +28,7 @@ gcloud compute ssh --zone $ZONE $instance -- "mkdir -p ~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/ann-benchmarks "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/weaviate-no-restart-on-crash/ "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse ann_benchmark_compression.sh "$instance:~"
-gcloud compute ssh --zone $ZONE $instance -- "WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_compression.sh"
+gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_compression.sh"
 mkdir -p results
 gcloud compute scp --zone $ZONE --recurse "$instance:~/results/*.json" results/
 

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -28,7 +28,7 @@ gcloud compute ssh --zone $ZONE $instance -- "mkdir -p ~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/ann-benchmarks "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/weaviate-no-restart-on-crash/ "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse ann_benchmark.sh "$instance:~"
-gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE $REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
+gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
 mkdir -p results
 gcloud compute scp --zone $ZONE --recurse "$instance:~/results/*.json" results/
 

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -28,7 +28,7 @@ gcloud compute ssh --zone $ZONE $instance -- "mkdir -p ~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/ann-benchmarks "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse apps/weaviate-no-restart-on-crash/ "$instance:~/apps/"
 gcloud compute scp --zone $ZONE --recurse ann_benchmark.sh "$instance:~"
-gcloud compute ssh --zone $ZONE $instance -- "WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
+gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE $REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
 mkdir -p results
 gcloud compute scp --zone $ZONE --recurse "$instance:~/results/*.json" results/
 

--- a/apps/ann-benchmarks/analyze.py
+++ b/apps/ann-benchmarks/analyze.py
@@ -18,7 +18,7 @@ class TestResults(unittest.TestCase):
     def test_max_recall(self):
         required_recall = 0.992
         rr_env = os.getenv("REQUIRED_RECALL")
-        if rr_env is not None:
+        if rr_env is not None and rr_env != "":
             required_recall = float(rr_env)
         max_recall = self.df["recall"].max()
         self.assertTrue(

--- a/apps/ann-benchmarks/analyze.py
+++ b/apps/ann-benchmarks/analyze.py
@@ -17,6 +17,9 @@ class TestResults(unittest.TestCase):
 
     def test_max_recall(self):
         required_recall = 0.992
+        rr_env = os.getenv("REQUIRED_RECALL")
+        if rr_env is not None:
+            required_recall = float(rr_env)
         max_recall = self.df["recall"].max()
         self.assertTrue(
             max_recall >= required_recall,


### PR DESCRIPTION
This adds two more AWS-builds that run with `glove-100-angular`?

## Why do we need an angular dataset?
Angular distance requires normalization, we had a bug that destroyed recall for angular datasets, but couldn't catch it with the pipeline because it only used a euclidean-based dataset

## Why only on AWS?
GCP is slower and the performance is unpredictable. It's questionable if we get any value out of the GCP pipelines in the current form. AWS is very stable and only has minimal fluctuation between runs.

## Why this particular dataset and not another angular-based one?
1. It's prominently featured in the official `ann-benchmarks` repo
2. It is large enough to be challenging, yet small enough to complete in the time that the longest existing chaos pipeline takes, so the total runtime won't be any longer because of this dataset.

