### PR TITLE
Add new pipeline for ref-imports in multi-node setting

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: preview-pq-with-rescoring-fe3af80
+  WEAVIATE_VERSION: preview-limit-concurrency-in-batch-validation-f2aec26
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
 on:
   push

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,532 +12,532 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
-  # ann-benchmarks-sift-aws:
-  #   name: "[bench AWS] SIFT1M pq=false"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  #     DATASET: sift-128-euclidean
-  #     DISTANCE: l2-squared
-  #     REQUIRED_RECALL: 0.999
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_aws.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # ann-benchmarks-glove-aws:
-  #   name: "[bench AWS] Glove100 pq=false"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  #     DATASET: glove-100-angular
-  #     DISTANCE: cosine
-  #     REQUIRED_RECALL: 0.965
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_aws.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # ann-benchmarks-pq-sift-aws:
-  #   name: "[bench AWS] SIFT1M pq=true"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  #     DATASET: sift-128-euclidean
-  #     DISTANCE: l2-squared
-  #     REQUIRED_RECALL: 0.992
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_compression_aws.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # ann-benchmarks-pq-glove-aws:
-  #   name: "[bench AWS] Glove100 pq=true"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-  #     DATASET: glove-100-angular
-  #     DISTANCE: cosine
-  #     REQUIRED_RECALL: 0.91
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_compression_aws.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # ann-benchmarks-sift-gcp:
-  #   name: "[bench GCP] SIFT1M pq=false"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     DATASET: sift-128-euclidean
-  #     DISTANCE: l2-squared
-  #     REQUIRED_RECALL: 0.999
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_gcp.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # ann-benchmarks-pq-sift-gcp:
-  #   name: "[bench GCP] SIFT1M pq=true"
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     DATASET: sift-128-euclidean
-  #     DISTANCE: l2-squared
-  #     REQUIRED_RECALL: 0.992
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - id: 'gcs_auth'
-  #       name: 'Authenticate to Google Cloud'
-  #       uses: 'google-github-actions/auth@v1'
-  #       with:
-  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-  #     - name: 'Set up Cloud SDK'
-  #       uses: 'google-github-actions/setup-gcloud@v1'
-  #     - name: Run chaos test
-  #       run: ./ann_benchmark_compression_gcp.sh
-  #     - id: 'upload-files'
-  #       uses: 'google-github-actions/upload-cloud-storage@v1'
-  #       with:
-  #         path: 'results'
-  #         destination: 'ann-pipelines/github-action-runs'
-  #         glob: '*.json'
-  # batch-import-many-classes:
-  #   name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./batch_import_many_classes.sh
-  # upgrade-journey:
-  #   name: Rolling updates in multi-node setup from min to target version
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v3
-  #       with:
-  #         go-version: '1.20'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./upgrade_journey.sh
-  # replicated-imports-with-choas-killing:
-  #   name: Replicated imports with chaos killing
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./replication_importing_while_crashing.sh
-  # replication-tunable-consistency:
-  #   name: Replication tunable consistency
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./replication_tunable_consistency.sh
-  # counting-while-compacting:
-  #   name: Counting while compacting
-  #   runs-on: ubuntu-latest-8-cores
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./counting_while_compacting.sh
-  # segfault-on-batch-ref:
-  #   name: Segfault on batch ref
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./segfault_batch_ref.sh
-  # import-with-kills:
-  #   name: Import during constant kills/crashes
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./import_while_crashing.sh
-  # heave-imports-crashing:
-  #   name: Heavy object store imports while crashing
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./import_while_crashing_no_vector.sh
-  # segfault-filtered-search:
-  #   name: Segfault on filtered vector search (race with hash bucket compaction)
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./segfault_filtered_vector_search.sh
-  # backup-restore-crud:
-  #   name: Backup & Restore CRUD
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_crud.sh
-  # backup-restore-crud-multi-node:
-  #   name: Backup & Restore multi node CRUD
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_multi_node_crud.sh
-  # backup-restore-version-compat:
-  #   name: Backup & Restore version compatibility
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./backup_and_restore_version_compatibility.sh
-  # compare-recall:
-  #   name: Compare Recall after import to after restart
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./compare_recall_after_restart.sh
-  # concurrent-read-write:
-  #   name: Concurrent inverted index read/write
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./concurrent_inverted_index_read_write.sh
-  # consecutive-create-update:
-  #   name: Consecutive create and update operations
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./consecutive_create_and_update_operations.sh
-  # batch-insert-missmatch:
-  #   name: Batch insert mismatch
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./consecutive_create_and_update_operations.sh
-  # rest-patch-restart:
-  #   name: REST PATCH requests stop working after restart
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./rest_patch_stops_working_after_restart.sh
-  # delete-recreate-updates:
-  #   name: Delete and recreate class with frequent updates
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./delete_and_recreate_class.sh
-  # geo-crash:
-  #   name: Preventing crashing of geo properties during HNSW maintenance cycles
-  #   runs-on: ubuntu-latest-8-cores
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./geo_crash.sh
-  # compaction-roaringset:
-  #   name: Preventing panic on compaction of roaringsets
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: Polar Signals Continuous Profiling
-  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-  #       with:
-  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{secrets.DOCKER_USERNAME}}
-  #         password: ${{secrets.DOCKER_PASSWORD}}
-  #     - name: Run chaos test
-  #       run: ./compaction_roaringset.sh
+  ann-benchmarks-sift-aws:
+    name: "[bench AWS] SIFT1M pq=false"
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.999
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-glove-aws:
+    name: "[bench AWS] Glove100 pq=false"
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: glove-100-angular
+      DISTANCE: cosine
+      REQUIRED_RECALL: 0.965
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-pq-sift-aws:
+    name: "[bench AWS] SIFT1M pq=true"
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.992
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_compression_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-pq-glove-aws:
+    name: "[bench AWS] Glove100 pq=true"
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: glove-100-angular
+      DISTANCE: cosine
+      REQUIRED_RECALL: 0.91
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_compression_aws.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-sift-gcp:
+    name: "[bench GCP] SIFT1M pq=false"
+    runs-on: ubuntu-latest
+    env:
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.999
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_gcp.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  ann-benchmarks-pq-sift-gcp:
+    name: "[bench GCP] SIFT1M pq=true"
+    runs-on: ubuntu-latest
+    env:
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.992
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        run: ./ann_benchmark_compression_gcp.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+  batch-import-many-classes:
+    name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./batch_import_many_classes.sh
+  upgrade-journey:
+    name: Rolling updates in multi-node setup from min to target version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./upgrade_journey.sh
+  replicated-imports-with-choas-killing:
+    name: Replicated imports with chaos killing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./replication_importing_while_crashing.sh
+  replication-tunable-consistency:
+    name: Replication tunable consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./replication_tunable_consistency.sh
+  counting-while-compacting:
+    name: Counting while compacting
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./counting_while_compacting.sh
+  segfault-on-batch-ref:
+    name: Segfault on batch ref
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./segfault_batch_ref.sh
+  import-with-kills:
+    name: Import during constant kills/crashes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./import_while_crashing.sh
+  heave-imports-crashing:
+    name: Heavy object store imports while crashing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./import_while_crashing_no_vector.sh
+  segfault-filtered-search:
+    name: Segfault on filtered vector search (race with hash bucket compaction)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./segfault_filtered_vector_search.sh
+  backup-restore-crud:
+    name: Backup & Restore CRUD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_crud.sh
+  backup-restore-crud-multi-node:
+    name: Backup & Restore multi node CRUD
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_multi_node_crud.sh
+  backup-restore-version-compat:
+    name: Backup & Restore version compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_version_compatibility.sh
+  compare-recall:
+    name: Compare Recall after import to after restart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./compare_recall_after_restart.sh
+  concurrent-read-write:
+    name: Concurrent inverted index read/write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./concurrent_inverted_index_read_write.sh
+  consecutive-create-update:
+    name: Consecutive create and update operations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./consecutive_create_and_update_operations.sh
+  batch-insert-missmatch:
+    name: Batch insert mismatch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./consecutive_create_and_update_operations.sh
+  rest-patch-restart:
+    name: REST PATCH requests stop working after restart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./rest_patch_stops_working_after_restart.sh
+  delete-recreate-updates:
+    name: Delete and recreate class with frequent updates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./delete_and_recreate_class.sh
+  geo-crash:
+    name: Preventing crashing of geo properties during HNSW maintenance cycles
+    runs-on: ubuntu-latest-8-cores
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./geo_crash.sh
+  compaction-roaringset:
+    name: Preventing panic on compaction of roaringsets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Polar Signals Continuous Profiling
+        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+        with:
+          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./compaction_roaringset.sh
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,190 +12,534 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
-  ann-benchmarks-sift-aws:
-    name: "[bench AWS] SIFT1M pq=false"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.999
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-glove-aws:
-    name: "[bench AWS] Glove100 pq=false"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: glove-100-angular
-      DISTANCE: cosine
-      REQUIRED_RECALL: 0.965
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-sift-aws:
-    name: "[bench AWS] SIFT1M pq=true"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.992
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-glove-aws:
-    name: "[bench AWS] Glove100 pq=true"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: glove-100-angular
-      DISTANCE: cosine
-      REQUIRED_RECALL: 0.91
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-sift-gcp:
-    name: "[bench GCP] SIFT1M pq=false"
-    runs-on: ubuntu-latest
-    env:
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.999
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_gcp.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-sift-gcp:
-    name: "[bench GCP] SIFT1M pq=true"
-    runs-on: ubuntu-latest
-    env:
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.992
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_gcp.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  batch-import-many-classes:
-    name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+  # ann-benchmarks-sift-aws:
+  #   name: "[bench AWS] SIFT1M pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.999
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-glove-aws:
+  #   name: "[bench AWS] Glove100 pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: glove-100-angular
+  #     DISTANCE: cosine
+  #     REQUIRED_RECALL: 0.965
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-sift-aws:
+  #   name: "[bench AWS] SIFT1M pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.992
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-glove-aws:
+  #   name: "[bench AWS] Glove100 pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: glove-100-angular
+  #     DISTANCE: cosine
+  #     REQUIRED_RECALL: 0.91
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-sift-gcp:
+  #   name: "[bench GCP] SIFT1M pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.999
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_gcp.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-sift-gcp:
+  #   name: "[bench GCP] SIFT1M pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.992
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_gcp.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # batch-import-many-classes:
+  #   name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./batch_import_many_classes.sh
+  # upgrade-journey:
+  #   name: Rolling updates in multi-node setup from min to target version
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: '1.20'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./upgrade_journey.sh
+  # replicated-imports-with-choas-killing:
+  #   name: Replicated imports with chaos killing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_importing_while_crashing.sh
+  # replication-tunable-consistency:
+  #   name: Replication tunable consistency
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_tunable_consistency.sh
+  # counting-while-compacting:
+  #   name: Counting while compacting
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./counting_while_compacting.sh
+  # segfault-on-batch-ref:
+  #   name: Segfault on batch ref
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_batch_ref.sh
+  # import-with-kills:
+  #   name: Import during constant kills/crashes
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing.sh
+  # heave-imports-crashing:
+  #   name: Heavy object store imports while crashing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing_no_vector.sh
+  # segfault-filtered-search:
+  #   name: Segfault on filtered vector search (race with hash bucket compaction)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_filtered_vector_search.sh
+  # backup-restore-crud:
+  #   name: Backup & Restore CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_crud.sh
+  # backup-restore-crud-multi-node:
+  #   name: Backup & Restore multi node CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_multi_node_crud.sh
+  # backup-restore-version-compat:
+  #   name: Backup & Restore version compatibility
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_version_compatibility.sh
+  # compare-recall:
+  #   name: Compare Recall after import to after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compare_recall_after_restart.sh
+  # concurrent-read-write:
+  #   name: Concurrent inverted index read/write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./concurrent_inverted_index_read_write.sh
+  # consecutive-create-update:
+  #   name: Consecutive create and update operations
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # batch-insert-missmatch:
+  #   name: Batch insert mismatch
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # rest-patch-restart:
+  #   name: REST PATCH requests stop working after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./rest_patch_stops_working_after_restart.sh
+  # delete-recreate-updates:
+  #   name: Delete and recreate class with frequent updates
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./delete_and_recreate_class.sh
+  # geo-crash:
+  #   name: Preventing crashing of geo properties during HNSW maintenance cycles
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./geo_crash.sh
+  # compaction-roaringset:
+  #   name: Preventing panic on compaction of roaringsets
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compaction_roaringset.sh
+  multi-node-references:
+    name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -210,334 +554,7 @@ jobs:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Run chaos test
-        run: ./batch_import_many_classes.sh
-  upgrade-journey:
-    name: Rolling updates in multi-node setup from min to target version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.20'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./upgrade_journey.sh
-  replicated-imports-with-choas-killing:
-    name: Replicated imports with chaos killing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_importing_while_crashing.sh
-  replication-tunable-consistency:
-    name: Replication tunable consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_tunable_consistency.sh
-  counting-while-compacting:
-    name: Counting while compacting
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./counting_while_compacting.sh
-  segfault-on-batch-ref:
-    name: Segfault on batch ref
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_batch_ref.sh
-  import-with-kills:
-    name: Import during constant kills/crashes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing.sh
-  heave-imports-crashing:
-    name: Heavy object store imports while crashing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing_no_vector.sh
-  segfault-filtered-search:
-    name: Segfault on filtered vector search (race with hash bucket compaction)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_filtered_vector_search.sh
-  backup-restore-crud:
-    name: Backup & Restore CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_crud.sh
-  backup-restore-crud-multi-node:
-    name: Backup & Restore multi node CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_multi_node_crud.sh
-  backup-restore-version-compat:
-    name: Backup & Restore version compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_version_compatibility.sh
-  compare-recall:
-    name: Compare Recall after import to after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compare_recall_after_restart.sh
-  concurrent-read-write:
-    name: Concurrent inverted index read/write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./concurrent_inverted_index_read_write.sh
-  consecutive-create-update:
-    name: Consecutive create and update operations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  batch-insert-missmatch:
-    name: Batch insert mismatch
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  rest-patch-restart:
-    name: REST PATCH requests stop working after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./rest_patch_stops_working_after_restart.sh
-  delete-recreate-updates:
-    name: Delete and recreate class with frequent updates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./delete_and_recreate_class.sh
-  geo-crash:
-    name: Preventing crashing of geo properties during HNSW maintenance cycles
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./geo_crash.sh
-  compaction-roaringset:
-    name: Preventing panic on compaction of roaringsets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compaction_roaringset.sh
+        run: ./multi_node_ref_imports.sh
   # Commented only because this chaos pipeline was able to interrupt save operation
   # just in the middle of it being performed and since Weaviate doesn't have a transaction
   # mechanism implemented then this was causing an error which is a different error then

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,532 +12,532 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
-  ann-benchmarks-sift-aws:
-    name: "[bench AWS] SIFT1M pq=false"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.999
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-glove-aws:
-    name: "[bench AWS] Glove100 pq=false"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: glove-100-angular
-      DISTANCE: cosine
-      REQUIRED_RECALL: 0.965
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-sift-aws:
-    name: "[bench AWS] SIFT1M pq=true"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.992
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-glove-aws:
-    name: "[bench AWS] Glove100 pq=true"
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      DATASET: glove-100-angular
-      DISTANCE: cosine
-      REQUIRED_RECALL: 0.91
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_aws.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-sift-gcp:
-    name: "[bench GCP] SIFT1M pq=false"
-    runs-on: ubuntu-latest
-    env:
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.999
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_gcp.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  ann-benchmarks-pq-sift-gcp:
-    name: "[bench GCP] SIFT1M pq=true"
-    runs-on: ubuntu-latest
-    env:
-      DATASET: sift-128-euclidean
-      DISTANCE: l2-squared
-      REQUIRED_RECALL: 0.992
-    steps:
-      - uses: actions/checkout@v3
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - id: 'gcs_auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1'
-        with:
-          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
-      - name: Run chaos test
-        run: ./ann_benchmark_compression_gcp.sh
-      - id: 'upload-files'
-        uses: 'google-github-actions/upload-cloud-storage@v1'
-        with:
-          path: 'results'
-          destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'
-  batch-import-many-classes:
-    name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./batch_import_many_classes.sh
-  upgrade-journey:
-    name: Rolling updates in multi-node setup from min to target version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.20'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./upgrade_journey.sh
-  replicated-imports-with-choas-killing:
-    name: Replicated imports with chaos killing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_importing_while_crashing.sh
-  replication-tunable-consistency:
-    name: Replication tunable consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./replication_tunable_consistency.sh
-  counting-while-compacting:
-    name: Counting while compacting
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./counting_while_compacting.sh
-  segfault-on-batch-ref:
-    name: Segfault on batch ref
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_batch_ref.sh
-  import-with-kills:
-    name: Import during constant kills/crashes
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing.sh
-  heave-imports-crashing:
-    name: Heavy object store imports while crashing
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./import_while_crashing_no_vector.sh
-  segfault-filtered-search:
-    name: Segfault on filtered vector search (race with hash bucket compaction)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./segfault_filtered_vector_search.sh
-  backup-restore-crud:
-    name: Backup & Restore CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_crud.sh
-  backup-restore-crud-multi-node:
-    name: Backup & Restore multi node CRUD
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_multi_node_crud.sh
-  backup-restore-version-compat:
-    name: Backup & Restore version compatibility
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./backup_and_restore_version_compatibility.sh
-  compare-recall:
-    name: Compare Recall after import to after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compare_recall_after_restart.sh
-  concurrent-read-write:
-    name: Concurrent inverted index read/write
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./concurrent_inverted_index_read_write.sh
-  consecutive-create-update:
-    name: Consecutive create and update operations
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  batch-insert-missmatch:
-    name: Batch insert mismatch
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./consecutive_create_and_update_operations.sh
-  rest-patch-restart:
-    name: REST PATCH requests stop working after restart
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./rest_patch_stops_working_after_restart.sh
-  delete-recreate-updates:
-    name: Delete and recreate class with frequent updates
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./delete_and_recreate_class.sh
-  geo-crash:
-    name: Preventing crashing of geo properties during HNSW maintenance cycles
-    runs-on: ubuntu-latest-8-cores
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./geo_crash.sh
-  compaction-roaringset:
-    name: Preventing panic on compaction of roaringsets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Polar Signals Continuous Profiling
-        uses: polarsignals/gh-actions-ps-profiling@v0.0.1
-        with:
-          polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
-          labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{secrets.DOCKER_USERNAME}}
-          password: ${{secrets.DOCKER_PASSWORD}}
-      - name: Run chaos test
-        run: ./compaction_roaringset.sh
+  # ann-benchmarks-sift-aws:
+  #   name: "[bench AWS] SIFT1M pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.999
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-glove-aws:
+  #   name: "[bench AWS] Glove100 pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: glove-100-angular
+  #     DISTANCE: cosine
+  #     REQUIRED_RECALL: 0.965
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-sift-aws:
+  #   name: "[bench AWS] SIFT1M pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.992
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-glove-aws:
+  #   name: "[bench AWS] Glove100 pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+  #     AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  #     DATASET: glove-100-angular
+  #     DISTANCE: cosine
+  #     REQUIRED_RECALL: 0.91
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_aws.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-sift-gcp:
+  #   name: "[bench GCP] SIFT1M pq=false"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.999
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_gcp.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # ann-benchmarks-pq-sift-gcp:
+  #   name: "[bench GCP] SIFT1M pq=true"
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     DATASET: sift-128-euclidean
+  #     DISTANCE: l2-squared
+  #     REQUIRED_RECALL: 0.992
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - id: 'gcs_auth'
+  #       name: 'Authenticate to Google Cloud'
+  #       uses: 'google-github-actions/auth@v1'
+  #       with:
+  #         credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+  #     - name: 'Set up Cloud SDK'
+  #       uses: 'google-github-actions/setup-gcloud@v1'
+  #     - name: Run chaos test
+  #       run: ./ann_benchmark_compression_gcp.sh
+  #     - id: 'upload-files'
+  #       uses: 'google-github-actions/upload-cloud-storage@v1'
+  #       with:
+  #         path: 'results'
+  #         destination: 'ann-pipelines/github-action-runs'
+  #         glob: '*.json'
+  # batch-import-many-classes:
+  #   name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./batch_import_many_classes.sh
+  # upgrade-journey:
+  #   name: Rolling updates in multi-node setup from min to target version
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v3
+  #       with:
+  #         go-version: '1.20'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./upgrade_journey.sh
+  # replicated-imports-with-choas-killing:
+  #   name: Replicated imports with chaos killing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_importing_while_crashing.sh
+  # replication-tunable-consistency:
+  #   name: Replication tunable consistency
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./replication_tunable_consistency.sh
+  # counting-while-compacting:
+  #   name: Counting while compacting
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./counting_while_compacting.sh
+  # segfault-on-batch-ref:
+  #   name: Segfault on batch ref
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_batch_ref.sh
+  # import-with-kills:
+  #   name: Import during constant kills/crashes
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing.sh
+  # heave-imports-crashing:
+  #   name: Heavy object store imports while crashing
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./import_while_crashing_no_vector.sh
+  # segfault-filtered-search:
+  #   name: Segfault on filtered vector search (race with hash bucket compaction)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./segfault_filtered_vector_search.sh
+  # backup-restore-crud:
+  #   name: Backup & Restore CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_crud.sh
+  # backup-restore-crud-multi-node:
+  #   name: Backup & Restore multi node CRUD
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_multi_node_crud.sh
+  # backup-restore-version-compat:
+  #   name: Backup & Restore version compatibility
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./backup_and_restore_version_compatibility.sh
+  # compare-recall:
+  #   name: Compare Recall after import to after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compare_recall_after_restart.sh
+  # concurrent-read-write:
+  #   name: Concurrent inverted index read/write
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./concurrent_inverted_index_read_write.sh
+  # consecutive-create-update:
+  #   name: Consecutive create and update operations
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # batch-insert-missmatch:
+  #   name: Batch insert mismatch
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./consecutive_create_and_update_operations.sh
+  # rest-patch-restart:
+  #   name: REST PATCH requests stop working after restart
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./rest_patch_stops_working_after_restart.sh
+  # delete-recreate-updates:
+  #   name: Delete and recreate class with frequent updates
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./delete_and_recreate_class.sh
+  # geo-crash:
+  #   name: Preventing crashing of geo properties during HNSW maintenance cycles
+  #   runs-on: ubuntu-latest-8-cores
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./geo_crash.sh
+  # compaction-roaringset:
+  #   name: Preventing panic on compaction of roaringsets
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: Polar Signals Continuous Profiling
+  #       uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+  #       with:
+  #         polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+  #         labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{secrets.DOCKER_USERNAME}}
+  #         password: ${{secrets.DOCKER_PASSWORD}}
+  #     - name: Run chaos test
+  #       run: ./compaction_roaringset.sh
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubuntu-latest

--- a/apps/multi-node-references/Dockerfile
+++ b/apps/multi-node-references/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim-bullseye
+RUN apt-get update && apt-get install -y curl unzip git
+
+WORKDIR /workdir
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY run.py ./

--- a/apps/multi-node-references/requirements.txt
+++ b/apps/multi-node-references/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.22.2
+loguru==0.5.3
+weaviate-client>=3.19.0

--- a/apps/multi-node-references/run.py
+++ b/apps/multi-node-references/run.py
@@ -2,6 +2,7 @@ import weaviate
 import uuid
 import random
 import os
+import sys
 from typing import Optional
 from loguru import logger
 
@@ -126,6 +127,7 @@ def handle_errors(results: Optional[dict]) -> None:
         The returned results for Batch creation.
     """
 
+    errord = False
     if results is not None:
         for result in results:
             if (
@@ -134,7 +136,10 @@ def handle_errors(results: Optional[dict]) -> None:
                 and "error" in result["result"]["errors"]
             ):
                 for message in result["result"]["errors"]["error"]:
+                    errord = True
                     logger.error(message["message"])
+    if errord:
+        sys.exit(1)
 
 
 do()

--- a/apps/multi-node-references/run.py
+++ b/apps/multi-node-references/run.py
@@ -1,0 +1,140 @@
+import weaviate
+import uuid
+import random
+import os
+from typing import Optional
+from loguru import logger
+
+
+def do():
+    targets = 200_000
+    origin = os.getenv("origin") or "http://localhost:8080"
+    client = weaviate.Client(origin)
+    client.schema.delete_all()
+    create_target_class(client)
+    load_targets(client, 0, targets)
+
+    create_source_class(client)
+    load_sources(client, 0, 1_000_000, 5, targets)
+
+
+def load_sources(client: weaviate.Client, start, end, ref_per_obj, targets):
+    client.batch.configure(batch_size=10_000, callback=handle_errors)
+    class_name = "Source"
+    with client.batch as batch:
+        for i in range(start, end):
+            if i % 10000 == 0:
+                logger.info(f"Class: {class_name} - writing record {i}/{end}")
+
+            refs = [
+                {
+                    "beacon": f"weaviate://localhost/Target/{str(uuid.UUID(int=random.randint(0,targets-1)))}"
+                }
+                for i in range(ref_per_obj)
+            ]
+
+            data_object = {
+                "index_id": i,
+                "toTarget": refs,
+            }
+
+            batch.add_data_object(
+                data_object=data_object,
+                class_name=class_name,
+                uuid=uuid.UUID(int=i),
+            )
+    logger.info(f"Finished writing {end-start} records")
+
+
+def load_targets(client: weaviate.Client, start, end):
+    client.batch.configure(batch_size=100, callback=handle_errors)
+    class_name = "Target"
+    with client.batch as batch:
+        for i in range(start, end):
+            if i % 10000 == 0:
+                logger.info(f"Class: {class_name} - writing record {i}/{end}")
+            data_object = {
+                "index_id": i,
+            }
+
+            batch.add_data_object(
+                data_object=data_object,
+                class_name=class_name,
+                uuid=uuid.UUID(int=i),
+            )
+    logger.info(f"Finished writing {end-start} records")
+
+
+def create_target_class(client: weaviate.Client):
+    class_obj = {
+        "vectorizer": "none",
+        "vectorIndexConfig": {
+            "efConstruction": 128,
+            "maxConnections": 16,
+            "ef": 256,
+            "cleanupIntervalSeconds": 10,
+        },
+        "class": "Target",
+        "invertedIndexConfig": {
+            "indexTimestamps": True,
+        },
+        "properties": [
+            {
+                "dataType": ["int"],
+                "name": "index_id",
+            },
+        ],
+    }
+
+    client.schema.create_class(class_obj)
+
+
+def create_source_class(client: weaviate.Client):
+    class_obj = {
+        "vectorizer": "none",
+        "vectorIndexConfig": {
+            "efConstruction": 128,
+            "maxConnections": 16,
+            "ef": 256,
+            "cleanupIntervalSeconds": 10,
+        },
+        "class": "Source",
+        "invertedIndexConfig": {
+            "indexTimestamps": True,
+        },
+        "properties": [
+            {
+                "dataType": ["int"],
+                "name": "index_id",
+            },
+            {
+                "dataType": ["Target"],
+                "name": "toTarget",
+            },
+        ],
+    }
+
+    client.schema.create_class(class_obj)
+
+
+def handle_errors(results: Optional[dict]) -> None:
+    """
+    Handle error message from batch requests logs the message as an info message.
+    Parameters
+    ----------
+    results : Optional[dict]
+        The returned results for Batch creation.
+    """
+
+    if results is not None:
+        for result in results:
+            if (
+                "result" in result
+                and "errors" in result["result"]
+                and "error" in result["result"]["errors"]
+            ):
+                for message in result["result"]["errors"]["error"]:
+                    logger.error(message["message"])
+
+
+do()

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -43,6 +43,7 @@ fi
 echo "Check for error logs"
 errors="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error | wc -l | tr -d '[:space:]')"
 if (( $warnings > 0 )); then 
+  docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error
   echo "too many errors ($errors)" 
   exit 1
 fi

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -36,7 +36,7 @@ if ! docker run \
   --network host \
   -t ref-importer python3 run.py; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml logs --tail 256
+  docker-compose -f apps/weaviate/docker-compose-replication.yml logs --tail 100
   exit 1
 fi
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -40,10 +40,10 @@ if ! docker run \
   exit 1
 fi
 
-echo "Check for warning logs"
-warnings="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep suspect | wc -l | tr -d '[:space:]')"
+echo "Check for error logs"
+errors="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error | wc -l | tr -d '[:space:]')"
 if (( $warnings > 0 )); then 
-  echo "too many warnings ($warnings)" 
+  echo "too many errors ($errors)" 
   exit 1
 fi
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+
+function wait_weaviate() {
+  echo "Wait for Weaviate to be ready"
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:$1; then
+      echo "Weaviate is ready"
+      break
+    fi
+
+    echo "Weaviate is not ready on $1, trying again in 1s"
+    sleep 1
+  done
+}
+
+echo "Building all required containers"
+( cd apps/multi-node-references && docker build -t ref-importer . )
+
+
+# We are reusing the replication docker-compose for this, but there is nothing
+# special about the infra, it's essentially just a 3-node cluster which is
+# perfect for this test
+echo "Starting Weaviate..."
+docker-compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1
+wait_weaviate 8080
+docker-compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-2
+wait_weaviate 8081
+docker-compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-3
+wait_weaviate 8082
+
+echo "Run import script in foreground..."
+if ! docker run \
+  -e 'ORIGIN=http://localhost:8080' \
+  --network host \
+  -t ref-importer python3 run.py; then
+  echo "Importer failed, printing latest Weaviate logs..."
+  docker-compose -f apps/weaviate/docker-compose.yml logs --tail 256
+  exit 1
+fi

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -48,5 +48,5 @@ if (( $warnings > 0 )); then
   exit 1
 fi
 
-echo "No warnings. Passed."
+echo "No errors. Passed."
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -36,6 +36,16 @@ if ! docker run \
   --network host \
   -t ref-importer python3 run.py; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose.yml logs --tail 256
+  docker-compose -f apps/weaviate/docker-compose-replication.yml logs --tail 256
   exit 1
 fi
+
+echo "Check for warning logs"
+warnings="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep suspect | wc -l | tr -d '[:space:]')"
+if (( $warnings > 0 )); then 
+  echo "too many warnings ($warnings)" 
+  exit 1
+fi
+
+echo "No warnings. Passed."
+


### PR DESCRIPTION
For context see:
* https://github.com/weaviate/weaviate/issues/3179
* https://github.com/weaviate/weaviate/pull/3180

New Pipeline:
* Import batches (containing many refs) into a 3-node cluster, all classes are shared across nodes, so network requests are inevitable for ref validation
* The pipeline fails if any batch insert has an error 
  * Old versions would fail for example after a node has been pronounced dead with something like "can't resolve hostname"
* Even if the imports pass, the pipeline would fail if there is a single `memberlist` log with level `error`
  * With the old version we see 10s or 100s of those  