### PR TITLE
Bump `weaviate-client[grpc]` from `v3.22.0b0` to `v3.25.0b0`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: 1.21.2
+  WEAVIATE_VERSION: preview-prep-release-v1-21-5-06030a8
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
 on:
   workflow_call:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: preview-prep-release-v1-21-5-06030a8
+  WEAVIATE_VERSION: 1.21.5
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
 on:
   workflow_call:

--- a/apps/ann-benchmarks/requirements.txt
+++ b/apps/ann-benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client[grpc]>=3.22.0b0
+weaviate-client[grpc]>=3.25.0b0
 loguru==0.5.3
 grpcio==1.53.0
 seaborn==0.12.2


### PR DESCRIPTION
This PR bumps the `weaviate-client[grpc]` dependency in `apps/ann-benchmarks` to use the new Python client pre-release tag that includes the recent breaking gRPC changes