### PR TITLE
add reasonable timeouts to avoid tests running for a (long) time

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
   ann-benchmarks-sift-aws:
     name: "[bench AWS] SIFT1M pq=false"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -64,6 +65,7 @@ jobs:
   ann-benchmarks-glove-aws:
     name: "[bench AWS] Glove100 pq=false"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -97,6 +99,7 @@ jobs:
   ann-benchmarks-pq-sift-aws:
     name: "[bench AWS] SIFT1M pq=true"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -130,6 +133,7 @@ jobs:
   ann-benchmarks-pq-glove-aws:
     name: "[bench AWS] Glove100 pq=true"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -163,6 +167,7 @@ jobs:
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -194,6 +199,7 @@ jobs:
   ann-benchmarks-pq-sift-gcp:
     name: "[bench GCP] SIFT1M pq=true"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -225,6 +231,7 @@ jobs:
   batch-import-many-classes:
     name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -244,6 +251,7 @@ jobs:
   upgrade-journey:
     name: Rolling updates in multi-node setup from min to target version
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -267,6 +275,7 @@ jobs:
   replicated-imports-with-choas-killing:
     name: Replicated imports with chaos killing
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -286,6 +295,7 @@ jobs:
   replicated-imports-with-backup:
     name: Replicated imports with backup loop
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -305,6 +315,7 @@ jobs:
   replication-tunable-consistency:
     name: Replication tunable consistency
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -324,6 +335,7 @@ jobs:
   counting-while-compacting:
     name: Counting while compacting
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -343,6 +355,7 @@ jobs:
   segfault-on-batch-ref:
     name: Segfault on batch ref
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -362,6 +375,7 @@ jobs:
   import-with-kills:
     name: Import during constant kills/crashes
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -381,6 +395,7 @@ jobs:
   heave-imports-crashing:
     name: Heavy object store imports while crashing
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -400,6 +415,7 @@ jobs:
   segfault-filtered-search:
     name: Segfault on filtered vector search (race with hash bucket compaction)
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -419,6 +435,7 @@ jobs:
   backup-restore-crud:
     name: Backup & Restore CRUD
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -438,6 +455,7 @@ jobs:
   backup-restore-crud-multi-node:
     name: Backup & Restore multi node CRUD
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -457,6 +475,7 @@ jobs:
   backup-restore-version-compat:
     name: Backup & Restore version compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -476,6 +495,7 @@ jobs:
   compare-recall:
     name: Compare Recall after import to after restart
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -495,6 +515,7 @@ jobs:
   concurrent-read-write:
     name: Concurrent inverted index read/write
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -514,6 +535,7 @@ jobs:
   consecutive-create-update:
     name: Consecutive create and update operations
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -533,6 +555,7 @@ jobs:
   batch-insert-mismatch:
     name: Batch insert mismatch
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -552,6 +575,7 @@ jobs:
   rest-patch-restart:
     name: REST PATCH requests stop working after restart
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -571,6 +595,7 @@ jobs:
   delete-recreate-updates:
     name: Delete and recreate class with frequent updates
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -590,6 +615,7 @@ jobs:
   geo-crash:
     name: Preventing crashing of geo properties during HNSW maintenance cycles
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -609,6 +635,7 @@ jobs:
   compaction-roaringset:
     name: Preventing panic on compaction of roaringsets
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -628,6 +655,7 @@ jobs:
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -647,6 +675,7 @@ jobs:
   multi-tenancy-concurrent-imports:
     name: Concurrent clients importing into multi-node cluster
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -666,6 +695,7 @@ jobs:
   multi_tenancy_activate_deactivate:
     name: Activate and deactivate tenants' shards
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:


### PR DESCRIPTION
By default GHA timeouts triggers after 6hrs. All our jobs takes less than 40min, most of them run in ~15mins. 

Set a default timeout for all of them of 60minutes so that in the future we can catch the ones running for too long/indefinitely/stuck/etc... faster.