### PR TITLE
Adjustment to chaos pipeline to improve stability

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
   run-jobs:
     strategy:
+      max-parallel: 15
       matrix:
         lsm_access_strategy: ['mmap', 'pread']
     uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,13 +24,13 @@ on:
         required: true
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v2
       - uses: psf/black@stable
   ann-benchmarks-sift-aws:
     name: "[bench AWS] SIFT1M pq=false"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -63,7 +63,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-glove-aws:
     name: "[bench AWS] Glove100 pq=false"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -96,7 +96,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-sift-aws:
     name: "[bench AWS] SIFT1M pq=true"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -129,7 +129,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-glove-aws:
     name: "[bench AWS] Glove100 pq=true"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -162,7 +162,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -193,7 +193,7 @@ jobs:
           glob: '*.json'
   ann-benchmarks-pq-sift-gcp:
     name: "[bench GCP] SIFT1M pq=true"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -224,7 +224,7 @@ jobs:
           glob: '*.json'
   batch-import-many-classes:
     name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -243,7 +243,7 @@ jobs:
         run: ./batch_import_many_classes.sh
   upgrade-journey:
     name: Rolling updates in multi-node setup from min to target version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -266,7 +266,7 @@ jobs:
         run: ./upgrade_journey.sh
   replicated-imports-with-choas-killing:
     name: Replicated imports with chaos killing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -285,7 +285,7 @@ jobs:
         run: ./replication_importing_while_crashing.sh
   replicated-imports-with-backup:
     name: Replicated imports with backup loop
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -304,7 +304,7 @@ jobs:
         run: ./replication_importing_with_backup.sh
   replication-tunable-consistency:
     name: Replication tunable consistency
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -342,7 +342,7 @@ jobs:
         run: ./counting_while_compacting.sh
   segfault-on-batch-ref:
     name: Segfault on batch ref
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -361,7 +361,7 @@ jobs:
         run: ./segfault_batch_ref.sh
   import-with-kills:
     name: Import during constant kills/crashes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -380,7 +380,7 @@ jobs:
         run: ./import_while_crashing.sh
   heave-imports-crashing:
     name: Heavy object store imports while crashing
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -399,7 +399,7 @@ jobs:
         run: ./import_while_crashing_no_vector.sh
   segfault-filtered-search:
     name: Segfault on filtered vector search (race with hash bucket compaction)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -418,7 +418,7 @@ jobs:
         run: ./segfault_filtered_vector_search.sh
   backup-restore-crud:
     name: Backup & Restore CRUD
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -437,7 +437,7 @@ jobs:
         run: ./backup_and_restore_crud.sh
   backup-restore-crud-multi-node:
     name: Backup & Restore multi node CRUD
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -456,7 +456,7 @@ jobs:
         run: ./backup_and_restore_multi_node_crud.sh
   backup-restore-version-compat:
     name: Backup & Restore version compatibility
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -475,7 +475,7 @@ jobs:
         run: ./backup_and_restore_version_compatibility.sh
   compare-recall:
     name: Compare Recall after import to after restart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -494,7 +494,7 @@ jobs:
         run: ./compare_recall_after_restart.sh
   concurrent-read-write:
     name: Concurrent inverted index read/write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -513,7 +513,7 @@ jobs:
         run: ./concurrent_inverted_index_read_write.sh
   consecutive-create-update:
     name: Consecutive create and update operations
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -532,7 +532,7 @@ jobs:
         run: ./consecutive_create_and_update_operations.sh
   batch-insert-mismatch:
     name: Batch insert mismatch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -551,7 +551,7 @@ jobs:
         run: ./consecutive_create_and_update_operations.sh
   rest-patch-restart:
     name: REST PATCH requests stop working after restart
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -570,7 +570,7 @@ jobs:
         run: ./rest_patch_stops_working_after_restart.sh
   delete-recreate-updates:
     name: Delete and recreate class with frequent updates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -608,7 +608,7 @@ jobs:
         run: ./geo_crash.sh
   compaction-roaringset:
     name: Preventing panic on compaction of roaringsets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -627,7 +627,7 @@ jobs:
         run: ./compaction_roaringset.sh
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -665,7 +665,7 @@ jobs:
         run: ./multi_tenancy_concurrent_importing.sh
   multi_tenancy_activate_deactivate:
     name: Activate and deactivate tenants' shards
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -689,7 +689,7 @@ jobs:
   # save it for future tests
   # compare-while-crashing:
   #   name: Compare REST and GraphQL while crashing
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest-4-cores
   #   steps:
   #     - uses: actions/checkout@v3
   #     - name: Login to Docker Hub

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
   ann-benchmarks-sift-aws:
     name: "[bench AWS] SIFT1M pq=false"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -64,6 +65,7 @@ jobs:
   ann-benchmarks-glove-aws:
     name: "[bench AWS] Glove100 pq=false"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -97,6 +99,7 @@ jobs:
   ann-benchmarks-pq-sift-aws:
     name: "[bench AWS] SIFT1M pq=true"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -130,6 +133,7 @@ jobs:
   ann-benchmarks-pq-glove-aws:
     name: "[bench AWS] Glove100 pq=true"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -163,6 +167,7 @@ jobs:
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -194,6 +199,7 @@ jobs:
   ann-benchmarks-pq-sift-gcp:
     name: "[bench GCP] SIFT1M pq=true"
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       DATASET: sift-128-euclidean
       DISTANCE: l2-squared
@@ -225,6 +231,7 @@ jobs:
   batch-import-many-classes:
     name: One class reveices long and expensive batches, user tries to create and delete 100s of classes in parallel
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -244,6 +251,7 @@ jobs:
   upgrade-journey:
     name: Rolling updates in multi-node setup from min to target version
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -267,6 +275,7 @@ jobs:
   replicated-imports-with-choas-killing:
     name: Replicated imports with chaos killing
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -286,6 +295,7 @@ jobs:
   replicated-imports-with-backup:
     name: Replicated imports with backup loop
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -305,6 +315,7 @@ jobs:
   replication-tunable-consistency:
     name: Replication tunable consistency
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -324,6 +335,7 @@ jobs:
   counting-while-compacting:
     name: Counting while compacting
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -343,6 +355,7 @@ jobs:
   segfault-on-batch-ref:
     name: Segfault on batch ref
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -362,6 +375,7 @@ jobs:
   import-with-kills:
     name: Import during constant kills/crashes
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -381,6 +395,7 @@ jobs:
   heave-imports-crashing:
     name: Heavy object store imports while crashing
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -400,6 +415,7 @@ jobs:
   segfault-filtered-search:
     name: Segfault on filtered vector search (race with hash bucket compaction)
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -419,6 +435,7 @@ jobs:
   backup-restore-crud:
     name: Backup & Restore CRUD
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -438,6 +455,7 @@ jobs:
   backup-restore-crud-multi-node:
     name: Backup & Restore multi node CRUD
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -457,6 +475,7 @@ jobs:
   backup-restore-version-compat:
     name: Backup & Restore version compatibility
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -476,6 +495,7 @@ jobs:
   compare-recall:
     name: Compare Recall after import to after restart
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -495,6 +515,7 @@ jobs:
   concurrent-read-write:
     name: Concurrent inverted index read/write
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -514,6 +535,7 @@ jobs:
   consecutive-create-update:
     name: Consecutive create and update operations
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -533,6 +555,7 @@ jobs:
   batch-insert-mismatch:
     name: Batch insert mismatch
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -552,6 +575,7 @@ jobs:
   rest-patch-restart:
     name: REST PATCH requests stop working after restart
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -571,6 +595,7 @@ jobs:
   delete-recreate-updates:
     name: Delete and recreate class with frequent updates
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -590,6 +615,7 @@ jobs:
   geo-crash:
     name: Preventing crashing of geo properties during HNSW maintenance cycles
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -609,6 +635,7 @@ jobs:
   compaction-roaringset:
     name: Preventing panic on compaction of roaringsets
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -628,6 +655,7 @@ jobs:
   multi-node-references:
     name: Large batches with many cross-refs on a multi-node cluster
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -647,6 +675,7 @@ jobs:
   multi-tenancy-concurrent-imports:
     name: Concurrent clients importing into multi-node cluster
     runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
@@ -666,6 +695,7 @@ jobs:
   multi_tenancy_activate_deactivate:
     name: Activate and deactivate tenants' shards
     runs-on: ubuntu-latest-4-cores
+    timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ condensing, etc.) do not degrade the quality of the vector index.
 Everything is entirely containerized and all pipelines can be started with
 simple bash scripts. You can find the scripts in the root folder, such as
 `./import_while_crashing.sh` and `./compare_recall_after_restart.sh`. Or simply
-check the travis file for an example. 
+check the Github actions YAML files for examples.
 
 ## Links 
 

--- a/apps/multi-tenancy-concurrent-imports/docker-compose-importers.yml
+++ b/apps/multi-tenancy-concurrent-imports/docker-compose-importers.yml
@@ -23,6 +23,8 @@ services:
       TOTAL_TENANTS: 1000
       OBJECTS_PER_TENANT: 1000
       TENANTS_PER_CYCLE: 50
+      IMPLICIT_TENANT_RATIO: 0
+      PROMETHEUS_PORT: 8000
     network_mode: 'host'
   importer-02:
     build: ./multi-tenancy-load-test/importer/
@@ -32,6 +34,8 @@ services:
       TOTAL_TENANTS: 1000
       OBJECTS_PER_TENANT: 1000
       TENANTS_PER_CYCLE: 50
+      IMPLICIT_TENANT_RATIO: 0
+      PROMETHEUS_PORT: 8001
     network_mode: 'host'
   importer-03:
     build: ./multi-tenancy-load-test/importer/
@@ -41,6 +45,8 @@ services:
       TOTAL_TENANTS: 1000
       OBJECTS_PER_TENANT: 1000
       TENANTS_PER_CYCLE: 50
+      IMPLICIT_TENANT_RATIO: 0
+      PROMETHEUS_PORT: 8003
     network_mode: 'host'
   importer-04:
     build: ./multi-tenancy-load-test/importer/
@@ -50,4 +56,6 @@ services:
       TOTAL_TENANTS: 1000
       OBJECTS_PER_TENANT: 1000
       TENANTS_PER_CYCLE: 50
+      IMPLICIT_TENANT_RATIO: 0
+      PROMETHEUS_PORT: 8004
     network_mode: 'host'


### PR DESCRIPTION
We see a lot of flaky timeout due to (we assume) resource starving. Add a concurrency limit to see if it helps with the flakyness due to resources constraints/starving.

Fixes:
* add IMPLICIT_TENANT_RATIO to env to avoid multi import pipeline fialing
* add timeouts to jobs to catch long running/stuck jobs earlier
* add concurrency limit on the matrix to avoid starving runners and triggering exhaustion failures
* use paid GHA runners instead of free runners