### PR TITLE
Add support for latest Weaviate Python client version 4.0 GA.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: 1.23.0
+  WEAVIATE_VERSION: 1.23.6
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
 on:
   workflow_call:

--- a/apps/ann-benchmarks/requirements.txt
+++ b/apps/ann-benchmarks/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client==4.3.b2
+weaviate-client==4.4.rc0
 loguru==0.5.3
 seaborn==0.12.2
 h5py==3.8.0

--- a/apps/ann-benchmarks/weaviate_query.py
+++ b/apps/ann-benchmarks/weaviate_query.py
@@ -3,7 +3,7 @@ import time
 import uuid
 import argparse
 import weaviate
-import weaviate.classes as wvc
+import weaviate.classes.config as wvc
 from weaviate.exceptions import WeaviateQueryException
 import h5py
 import json
@@ -16,7 +16,7 @@ class_name = "Vector"
 results = []
 
 
-def search_grpc(collection: weaviate.Collection, dataset, i, input_vec):
+def search_grpc(collection: weaviate.collections.Collection, dataset, i, input_vec):
     out = {}
     before = time.time()
     try:
@@ -49,14 +49,14 @@ def query(client: weaviate.WeaviateClient, stub, dataset, ef_values, labels):
 
     for ef in ef_values:
         for api in ["grpc"]:
-            collection.config.update(vector_index_config=wvc.Reconfigure.vector_index(ef=ef))
+            collection.config.update(vector_index_config=wvc.Reconfigure.VectorIndex.hnsw(ef=ef))
 
             took = 0
             recall = 0
             for i, vec in enumerate(vectors):
                 res = {}
                 if api == "grpc":
-                    res = search_grpc(collection, dataset, i, vec)
+                    res = search_grpc(collection, dataset, i, list(vec))
                 elif api == "grpc_clientless":
                     res = search_grpc_clientless(stub, dataset, i, vec)
                 elif api == "graphql":

--- a/apps/rest-patch-stops-working-after-restart/rest-patch-stops-working-after-restart.py
+++ b/apps/rest-patch-stops-working-after-restart/rest-patch-stops-working-after-restart.py
@@ -1,6 +1,7 @@
 """
 https://semi-technology.atlassian.net/browse/WEAVIATE-151
 """
+
 import sys
 from typing import Dict
 import weaviate


### PR DESCRIPTION
This PR adapts the ann-benchmark code to support the latest changes from the Weaviate's Python client version 4.

All changes were tested with the most recent version, weaviate-client-4.4b9.dev254+g14ba0392, besides the version 4.4.rc0. So, it working with the GA version of the python client which will be released in couple of days.