### PR TITLE
Fix backup and restore version compatibility data verification

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: 1.24.2
+  WEAVIATE_VERSION: 1.24.3
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
   DISABLE_RECOVERY_ON_PANIC: true
 

--- a/apps/backup_and_restore_version_compatibility/generate_version_pairs.py
+++ b/apps/backup_and_restore_version_compatibility/generate_version_pairs.py
@@ -33,9 +33,9 @@ def get_version_tags():
 
 
 def is_version_since_backup_introduced(tag):
-    # backups were introduced starting from v1.15.0
+    # restoring backups older than 1.17.0 isn't possible after 1.23.0
     parts = tag.split(".")
-    if int(parts[0]) > 1 or int(parts[1]) >= 15:
+    if int(parts[0]) > 1 or int(parts[1]) >= 17:
         return True
     return False
 


### PR DESCRIPTION
After an incident raised by our SREs in which they couldn't restore a backup obtained when the cluster was in 1.22.5 into a newly created backup in 1.24.0 I decided to dig into the backup_and_restore_version_compatibility pipeline and found out that the issue was also occurring, but it was not caught by the job because the verification logic didn't take into consideration the case in which the query returns an empty list.

This PR fixes the pipeline by comparing the number of items from source node and destination node, as well as the content for each item retrieved in the query. 

Also, it updates the WEAVIATE_VERSION to 1.24.3, which includes the fix for this issue.