### PR TITLE
Add chaos-pipeline to verify and catch schema out-of-sync after backup restore

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: 1.24.3
+  WEAVIATE_VERSION: 1.24.6
   MINIMUM_WEAVIATE_VERSION: 1.15.0 # this is used as the start in the upgrade journey test
   DISABLE_RECOVERY_ON_PANIC: true
 
@@ -775,6 +775,27 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Run chaos test
         run: ./backup_and_flush.sh
+  backup_and_restore_out_of_sync:
+    # https://github.com/weaviate/weaviate/pull/4541
+    name: Test that restoring a backup without data presence ensures schema consistency across nodes
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
+    steps:
+      - uses: actions/checkout@v3
+      # - name: Polar Signals Continuous Profiling
+      #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
+      #   with:
+      #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
+      #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run chaos test
+        run: ./backup_and_restore_multi_node_out_of_sync.sh
   # Commented only because this chaos pipeline was able to interrupt save operation
   # just in the middle of it being performed and since Weaviate doesn't have a transaction
   # mechanism implemented then this was causing an error which is a different error then

--- a/apps/backup_and_restore_out_of_sync/Dockerfile
+++ b/apps/backup_and_restore_out_of_sync/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim-bullseye
+
+WORKDIR /workdir
+
+ARG backend
+ENV BACKUP_BACKEND_PROVIDER=${backend}
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY backup_and_restore_out_of_sync.py ./

--- a/apps/backup_and_restore_out_of_sync/backup_and_restore_out_of_sync.py
+++ b/apps/backup_and_restore_out_of_sync/backup_and_restore_out_of_sync.py
@@ -1,0 +1,143 @@
+import datetime
+import os
+import requests
+import sys
+import time
+import weaviate
+
+from loguru import logger
+
+
+def create_class(client: weaviate.Client, class_name):
+    class_obj = {
+        "class": class_name,
+        "vectorizer": "none",
+        "invertedIndexConfig": {"bm25": {"b": 0.75, "k1": 1.2}},
+        "replicationConfig": {"factor": 1},
+        "shardingConfig": {
+            "desiredCount": 1,
+        },
+        "properties": [
+            {
+                "name": "title",
+                "description": "TITLE",
+                "dataType": ["text"],
+                "indexSearchable": True,
+                "indexSearchable": True,
+                "indexFilterable": True,
+            }
+        ],
+    }
+    client.schema.create_class(class_obj)
+
+
+def reset_schema(client1: weaviate.Client, client2: weaviate.Client):
+    client1.schema.delete_all()
+
+    for i in range(0, 50):
+        create_class(client1, f"Books1_{i}")
+
+    for i in range(50, 100):
+        create_class(client2, f"Books1_{i}")
+
+
+def query_collections(client1: weaviate.Client, client2: weaviate.Client):
+
+    logger.info(f"Length of collection from node 1: {len(client1.schema.get()['classes'])}")
+    logger.info(f"Length of collection from node 2: {len(client2.schema.get()['classes'])}")
+    for i in range(0, 100):
+        collection1 = client1.schema.get(f"Books1_{i}")
+        collection2 = client2.schema.get(f"Books1_{i}")
+
+        if collection1["class"] != collection2["class"]:
+            fatal(f"Collection name is not correct")
+
+
+def fatal(msg):
+    logger.error(msg)
+    sys.exit(1)
+
+
+def success(msg):
+    logger.success(msg)
+
+
+def backend_provider():
+    backend = os.environ.get("BACKUP_BACKEND_PROVIDER")
+    if backend is None or backend == "":
+        return "filesystem"
+    return backend
+
+
+def temp_backup_url_create():
+    return f"http://localhost:8081/v1/backups/{backend_provider()}"
+
+
+def temp_backup_url_create_status(backup_name):
+    return f"http://localhost:8080/v1/backups/{backend_provider()}/{backup_name}"
+
+
+def temp_backup_url_restore(backup_name):
+    return f"http://localhost:8081/v1/backups/{backend_provider()}/{backup_name}/restore"
+
+
+def temp_backup_url_restore_status(backup_name):
+    return f"http://localhost:8080/v1/backups/{backend_provider()}/{backup_name}/restore"
+
+
+def create_backup(client: weaviate.WeaviateClient, name):
+    create_body = {"id": name}
+    res = requests.post(temp_backup_url_create(), json=create_body)
+    if res.status_code > 399:
+        fatal(f"Backup Create returned status code {res.status_code} with body: {res.json()}")
+
+    while True:
+        time.sleep(3)
+        res = requests.get(temp_backup_url_create_status(name))
+        res_json = res.json()
+        if res_json["status"] == "SUCCESS":
+            success(f"Backup creation successful")
+            break
+        if res_json["status"] == "FAILED":
+            fatal(f"Backup failed with res: {res_json}")
+
+
+def restore_backup(client: weaviate.WeaviateClient, name):
+    restore_body = {"id": name}
+    res = requests.post(temp_backup_url_restore(name), json=restore_body)
+    if res.status_code > 399:
+        fatal(f"Backup Restore returned status code {res.status_code} with body: {res.json()}")
+
+    while True:
+        time.sleep(3)
+        res = requests.get(temp_backup_url_restore_status(name))
+        res_json = res.json()
+        if res_json["status"] == "SUCCESS":
+            success(f"Restore succeeded")
+            break
+        if res_json["status"] == "FAILED":
+            fatal(f"Restore failed with res: {res_json}")
+
+
+client1 = weaviate.Client(url="http://localhost:8080")
+client2 = weaviate.Client(url="http://localhost:8081")
+
+backup_name = f"{int(datetime.datetime.now().timestamp())}_stage_1"
+
+logger.info(f"Step 0, reset everything, import schema")
+reset_schema(client1, client2)
+
+logger.info(f"Step 1, query each class from both nodes")
+query_collections(client1, client2)
+
+logger.info("Step 2, create backup using node 2")
+create_backup(client1, backup_name)
+
+logger.info("Step 3, delete the schema and all objects")
+client1.schema.delete_all()
+
+logger.info("Step 4, restore backup using node 2")
+restore_backup(client1, backup_name)
+
+logger.info(f"Step 5, query each class from both nodes")
+query_collections(client1, client2)

--- a/apps/backup_and_restore_out_of_sync/requirements.txt
+++ b/apps/backup_and_restore_out_of_sync/requirements.txt
@@ -1,0 +1,4 @@
+weaviate-client>=3.9.0
+numpy==1.22.2
+loguru==0.5.3
+

--- a/backup_and_restore_multi_node_out_of_sync.sh
+++ b/backup_and_restore_multi_node_out_of_sync.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This pipeline is based on the following scenario: https://semi-technology.atlassian.net/browse/WEAVIATE-737
+# which caused a disruptive issue in one of our customers' production environment.
+
+set -e
+
+function wait_weaviate_cluster() {
+  echo "Wait for Weaviate to be ready"
+  local node1_ready=false
+  local node2_ready=false
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:8080; then
+      echo "Weaviate node1 is ready"
+      node1_ready=true
+    fi
+
+    if curl -sf -o /dev/null localhost:8081; then
+      echo "Weaviate node2 is ready"
+      node2_ready=true
+    fi
+
+    if $node1_ready && $node2_ready; then
+      break
+    fi
+
+    echo "Weaviate cluster is not ready, trying again in 1s"
+    sleep 1
+  done
+}
+
+echo "Building all required containers"
+( cd apps/backup_and_restore_out_of_sync/ && docker build -t backup_and_restore_out_of_sync \
+  --build-arg backend="s3" . )
+
+export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
+export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
+
+echo "Starting Weaviate..."
+docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+
+wait_weaviate_cluster
+
+echo "Creating S3 bucket..."
+docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+
+echo "Run multi-node backup and restore which affects schema"
+docker run --network host -t backup_and_restore_out_of_sync python3 backup_and_restore_out_of_sync.py
+
+echo "Passed!"


### PR DESCRIPTION
This new pipeline creates a set of 100 classes in a 2-node cluster. Performs a backup, deletes the schema and restores the backup. The issue was that when restoring the data the second node was out of sync with the first one. This issue got fixed in 1.24.6, so bumping the WEAVIATE_VERSION too.