### PR TITLE
update raft image

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: preview--9c16847
+  WEAVIATE_VERSION: 1.25.0-raft-f216c6a
   DISABLE_RECOVERY_ON_PANIC: true
 on:
   workflow_call:


### PR DESCRIPTION
Update the image used in the CI to take the latest build of the main branch of the weaviate repo. Image tag from https://github.com/weaviate/weaviate/actions/runs/8672647190/job/23783262586