### PR TITLE
fix: rolling update in single nodes test

### DIFF
--- a/apps/upgrade-journey/containers.go
+++ b/apps/upgrade-journey/containers.go
@@ -123,9 +123,8 @@ func (c *cluster) startWeaviateNode(ctx context.Context, nodeId int, version str
 				"CLUSTER_DATA_BIND_PORT":                  "7101",
 				"CLUSTER_HOSTNAME":                        c.hostname(nodeId),
 				"CLUSTER_JOIN":                            c.allNodes(),
-				"RAFT_JOIN":                               c.hostname(0),
+				"RAFT_JOIN":                               fmt.Sprintf("%s:8300", c.hostname(nodeId)),
 				"RAFT_BOOTSTRAP_EXPECT":                   "1",
-				"RAFT_RECOVERY_TIMEOUT":                   "10",
 				"PERSISTENCE_LSM_ACCESS_STRATEGY":         os.Getenv("PERSISTENCE_LSM_ACCESS_STRATEGY"),
 			},
 			Mounts: testcontainers.Mounts(testcontainers.BindMount(

--- a/apps/upgrade-journey/versions.go
+++ b/apps/upgrade-journey/versions.go
@@ -194,7 +194,7 @@ func getTargetVersion(ctx context.Context, version string) (string, error) {
 		"PERSISTENCE_DATA_PATH":     "./data",
 		"DEFAULT_VECTORIZER_MODULE": "none",
 		"CLUSTER_HOSTNAME":          "weaviate-test",
-		"RAFT_JOIN":                 "weaviate-test",
+		"RAFT_JOIN":                 "weaviate-test:8300",
 		"RAFT_BOOTSTRAP_EXPECT":     "1",
 	}
 	req := testcontainers.ContainerRequest{


### PR DESCRIPTION
fix configuration for `RAFT_JOIN` for rolling update in singlre nodes test