### PR TITLE
Stabilize test failing due to graphQL ready delay

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,7 +1,7 @@
 name: Chaos tests
 
 env:
-  WEAVIATE_VERSION: 1.25.0-raft-f216c6a
+  WEAVIATE_VERSION: 1.25.0-raft-ac8cbc4
   DISABLE_RECOVERY_ON_PANIC: true
 on:
   workflow_call:

--- a/apps/multi-node-references/requirements.txt
+++ b/apps/multi-node-references/requirements.txt
@@ -1,3 +1,4 @@
 numpy==1.22.2
 loguru==0.5.3
 weaviate-client>=3.19.0
+backoff==2.2.1

--- a/apps/upgrade-journey/containers.go
+++ b/apps/upgrade-journey/containers.go
@@ -62,12 +62,14 @@ func (c *cluster) rollingUpdate(ctx context.Context, version string) error {
 		container, err := c.startWeaviateNode(ctx, i, version)
 		if err != nil {
 			log.Print(err)
-			logReader, logErr := container.Logs(context.Background())
-			if logErr != nil {
-				log.Fatal(logErr)
-			}
+			if container != nil {
+				logReader, logErr := container.Logs(context.Background())
+				if logErr != nil {
+					log.Fatal(logErr)
+				}
 
-			io.Copy(os.Stdout, logReader)
+				io.Copy(os.Stdout, logReader)
+			}
 			return err
 		}
 


### PR DESCRIPTION
Add a polling mechanism to have the upgrade test proceed once graphQL has the schema realoaded (graphql fix)
Add a polling mechanism to have large cluster import proceed once the class is present in the schema (EC fix)
Fix nil pointer lookup in upgrade journey test
Make tunable replication consistency test dump logs when failing