### PR TITLE
Run Send Slack message even if previous task fails.

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -23,7 +23,7 @@ jobs:
   weaviate-version-information:
     runs-on: ubuntu-latest
     env:
-      weaviate_version: "${{inputs.weaviate_version || '1.25.1'}}"
+      weaviate_version: "${{inputs.weaviate_version || '1.25.2'}}"
     steps:
       - run: |
           echo "Running chaos pipelines against Weaviate version: $weaviate_version" >> $GITHUB_STEP_SUMMARY
@@ -35,7 +35,7 @@ jobs:
     uses: ./.github/workflows/tests.yaml
     with:
       lsm_access_strategy: ${{matrix.lsm_access_strategy}}
-      weaviate_version: ${{ github.event_name == 'schedule' && 'latest' || inputs.weaviate_version || '1.25.1' }}
+      weaviate_version: ${{ github.event_name == 'schedule' && 'latest' || inputs.weaviate_version || '1.25.2' }}
     secrets:
       AWS_ACCESS_KEY: ${{secrets.AWS_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
@@ -45,7 +45,7 @@ jobs:
       POLARSIGNALS_TOKEN: ${{secrets.POLARSIGNALS_TOKEN}}
   send-slack-message-on-failure:
     needs: run-with-sync-indexing
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' }} && failure()
     runs-on: ubuntu-latest
     steps:
       - name: Check job status


### PR DESCRIPTION
Also, updates the chaos-pipeline into using 1.25.2 version instead.