### PR TITLE
Fix numpy version incompatibility with h5py.

### DIFF
--- a/apps/ann-benchmarks/requirements.txt
+++ b/apps/ann-benchmarks/requirements.txt
@@ -1,5 +1,5 @@
 weaviate-client==4.4.rc0
 loguru==0.5.3
 seaborn==0.12.2
-h5py==3.8.0
-pandas==2.0.0
+h5py==3.11.0
+pandas==2.2.2


### PR DESCRIPTION
Most of the ann-benchmark tests are failing with:
numpy.dtype size changed, may indicate binary incompatibility. Using numpy version older than 1.20.0 fixes the problem