### PR TITLE
Replace docker-compose by docker compose.

### DIFF
--- a/apps/bm25-corruption/Dockerfile
+++ b/apps/bm25-corruption/Dockerfile
@@ -3,7 +3,6 @@ FROM python
 WORKDIR /app
 
 COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=docker:latest /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 COPY requirements.txt .
 

--- a/apps/chaotic-cluster-killer/Dockerfile
+++ b/apps/chaotic-cluster-killer/Dockerfile
@@ -7,6 +7,5 @@ RUN ["apk", "add", "curl", "bash"]
 COPY run.sh .
 
 COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=docker:latest /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 CMD ["bash", "/chaos/run.sh"]

--- a/apps/chaotic-cluster-killer/run.sh
+++ b/apps/chaotic-cluster-killer/run.sh
@@ -25,8 +25,8 @@ while true; do
   sleep "$sleepsec"
 
   echo killing now
-    docker-compose -f apps/weaviate/docker-compose-replication.yml kill $container_name \
-      && docker-compose -f apps/weaviate/docker-compose-replication.yml up -d $container_name
+    docker compose -f apps/weaviate/docker-compose-replication.yml kill $container_name \
+      && docker compose -f apps/weaviate/docker-compose-replication.yml up -d $container_name
 
 done
 

--- a/apps/chaotic-killer/Dockerfile
+++ b/apps/chaotic-killer/Dockerfile
@@ -7,6 +7,5 @@ RUN ["apk", "add", "curl", "bash"]
 COPY run.sh .
 
 COPY --from=docker:latest /usr/local/bin/docker /usr/local/bin/docker
-COPY --from=docker:latest /usr/local/bin/docker-compose /usr/local/bin/docker-compose
 
 CMD ["bash", "/chaos/run.sh"]

--- a/apps/chaotic-killer/run.sh
+++ b/apps/chaotic-killer/run.sh
@@ -42,8 +42,8 @@ while true; do
 
   echo killing now
   if [[ "${CHAOTIC_KILL_DOCKER}" == "y" ]]; then
-    docker-compose -f apps/weaviate/docker-compose.yml kill weaviate \
-      && docker-compose -f apps/weaviate/docker-compose.yml up weaviate -d
+    docker compose -f apps/weaviate/docker-compose.yml kill weaviate \
+      && docker compose -f apps/weaviate/docker-compose.yml up weaviate -d
   else
     docker exec $CONTAINER_ID /bin/sh -c 'ps aux | grep '"'"'weaviate'"'"' | grep -v grep | awk '"'"'{print $1}'"'"' | xargs kill -9'
   fi

--- a/apps/replicated_import_with_backup/docker-compose.yml
+++ b/apps/replicated_import_with_backup/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+---
 services:
   weaviate-node-1: # same as extended service to avoid reconfiguring cluster comm
     extends:

--- a/apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml
+++ b/apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate:
     init: true

--- a/apps/weaviate-no-restart-on-crash/docker-compose.yml
+++ b/apps/weaviate-no-restart-on-crash/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate:
     init: true

--- a/apps/weaviate/docker-compose-backup.yml
+++ b/apps/weaviate/docker-compose-backup.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate-node-1:
     init: true

--- a/apps/weaviate/docker-compose-c11y.yml
+++ b/apps/weaviate/docker-compose-c11y.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.4'
 services:
   weaviate:
     command:

--- a/apps/weaviate/docker-compose-cpu-constrained.yml
+++ b/apps/weaviate/docker-compose-cpu-constrained.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate:
     init: true

--- a/apps/weaviate/docker-compose-replication.yml
+++ b/apps/weaviate/docker-compose-replication.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate-node-1:
     init: true

--- a/apps/weaviate/docker-compose-replication_single_voter.yml
+++ b/apps/weaviate/docker-compose-replication_single_voter.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate-node-1:
     init: true

--- a/apps/weaviate/docker-compose-single-voter-without-node-name.yml
+++ b/apps/weaviate/docker-compose-single-voter-without-node-name.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate-node-1:
     init: true

--- a/apps/weaviate/docker-compose.yml
+++ b/apps/weaviate/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3.9'
 services:
   weaviate:
     init: true

--- a/backup_and_flush.sh
+++ b/backup_and_flush.sh
@@ -19,7 +19,7 @@ echo "Building all required containers"
 ( cd apps/backup-and-flush/ && docker build -t backup_and_flush . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/backup_and_restore_crud.sh
+++ b/backup_and_restore_crud.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/backup_and_restore_multi_node_crud.sh
+++ b/backup_and_restore_multi_node_crud.sh
@@ -41,12 +41,12 @@ export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
 export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
 
 wait_weaviate_cluster
 
 echo "Creating S3 bucket..."
-docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
 
 echo "Run multi-node backup and restore CRUD operations"
 docker run --network host -t backup_and_restore_crud python3 backup_and_restore_crud.py

--- a/backup_and_restore_multi_node_out_of_sync.sh
+++ b/backup_and_restore_multi_node_out_of_sync.sh
@@ -36,12 +36,12 @@ export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
 export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
 
 wait_weaviate_cluster
 
 echo "Creating S3 bucket..."
-docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
 
 echo "Run multi-node backup and restore which affects schema"
 docker run --network host -t backup_and_restore_out_of_sync python3 backup_and_restore_out_of_sync.py

--- a/backup_and_restore_version_compatibility.sh
+++ b/backup_and_restore_version_compatibility.sh
@@ -58,21 +58,21 @@ for pair in "${!version_pairs[@]}"; do
   export WEAVIATE_NODE_2_VERSION=$restore_version
 
   echo "Starting Weaviate cluster..."
-  docker-compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-backup-node backup-s3
+  docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-backup-node backup-s3
 
   wait_weaviate_cluster
 
   echo "Creating S3 bucket..."
-  docker-compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+  docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
 
   echo "Run backup (v${backup_version}) and restore (v${restore_version}) version compatibility operations"
   docker run --rm --network host -t backup_and_restore_version_compatibility python3 backup_and_restore_version_compatibility.py
 
   echo "Removing S3 bucket..."
-  docker-compose -f apps/weaviate/docker-compose-backup.yml up remove-s3-bucket
+  docker compose -f apps/weaviate/docker-compose-backup.yml up remove-s3-bucket
 
   echo "Cleaning up containers for next test..."
-  docker-compose -f apps/weaviate/docker-compose-backup.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose-backup.yml down --remove-orphans
 done
 
 echo "Passed!"

--- a/batch_import_many_classes.sh
+++ b/batch_import_many_classes.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/batch-import-many-classes/ && docker build -t batch_import_many_classes . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/batch_insert_mismatch.sh
+++ b/batch_insert_mismatch.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/batch-insert-mismatch/ && docker build -t batch-insert-mismatch . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-c11y.yml up -d
+docker compose -f apps/weaviate/docker-compose-c11y.yml up -d
 
 wait_weaviate
 

--- a/bm25_corruption.sh
+++ b/bm25_corruption.sh
@@ -23,12 +23,12 @@ echo "Building all required containers"
 ( cd apps/bm25-corruption/ && docker build -t importer . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
 function debug_logs() {
-  docker-compose -f apps/weaviate/docker-compose.yml logs --tail 100
+  docker compose -f apps/weaviate/docker-compose.yml logs --tail 100
 }
 trap debug_logs ERR
 

--- a/compaction_roaringset.sh
+++ b/compaction_roaringset.sh
@@ -21,12 +21,12 @@ echo "Building all required containers"
 ( cd apps/compaction-roaringset/ && docker build -t compaction-roaringset . )
 
 echo "Starting Weaviate..."
-PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS=1 docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS=1 docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
 
 wait_weaviate
 
 function dump_logs() {
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
 }
 
 trap 'dump_logs' ERR

--- a/compare_recall_after_restart.sh
+++ b/compare_recall_after_restart.sh
@@ -31,7 +31,7 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" -t reca
 echo "Done generating."
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
@@ -42,8 +42,8 @@ echo "Check Recall"
 docker run --network host -v "$PWD/workdir/:/app/data" -t recall-checker
 
 echo "Restart Weaviate"
-docker-compose -f apps/weaviate/docker-compose.yml stop weaviate && \
-  docker-compose -f apps/weaviate/docker-compose.yml start weaviate
+docker compose -f apps/weaviate/docker-compose.yml stop weaviate && \
+  docker compose -f apps/weaviate/docker-compose.yml start weaviate
 
 wait_weaviate
 

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -22,7 +22,7 @@ echo "Building all required containers"
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/concurrent_inverted_index_read_write.sh
+++ b/concurrent_inverted_index_read_write.sh
@@ -24,7 +24,7 @@ echo "Building all required containers"
 ( cd apps/importer-concurrent-inverted-index/ && docker build -t importer . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
@@ -38,7 +38,7 @@ if ! docker run \
   --network host \
   -t importer; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose.yml logs weaviate
+  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
   exit 1
 fi
 

--- a/consecutive_create_and_update_operations.sh
+++ b/consecutive_create_and_update_operations.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/consecutive_create_and_update_operations/ && docker build -t consecutive_create_and_update_operations . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/counting_while_compacting.sh
+++ b/counting_while_compacting.sh
@@ -21,12 +21,12 @@ echo "Building all required containers"
 ( cd apps/counting-while-compacting/ && docker build -t counting-while-compacting . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
 
 wait_weaviate
 
 function dump_logs() {
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
   docker ps -a
 }
 

--- a/delete_and_recreate_class.sh
+++ b/delete_and_recreate_class.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/delete_and_recreate && docker build -t delete_and_recreate . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/deletes_with_node_out_of_sync.sh
+++ b/deletes_with_node_out_of_sync.sh
@@ -54,7 +54,7 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 echo "Done generating."
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -66,7 +66,7 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -74,33 +74,33 @@ fi
 docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name regenerator -t regenerator
 
 echo "Killing node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
 sleep 10
 # Import tenant2 objects with one node down, consistency level QUORUM
 docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name reimporter -t reimporter
 
 # Restart dead node, read objects from Node 3 with consistency level ONE
 echo "Restart node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
 wait_weaviate 8082
 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name check_objects_in_nodes -t check_objects_in_nodes; then
   echo "tenant2 objects are present in Node 1 but not in Node 3, as it was down."
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name deleter -t deleter; then
   echo "All tenant2 objects deleted with consistency level ONE."
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name check_objects_deleted -t check_objects_deleted; then
   echo "tenant2 objects were deleted from all nodes."
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi

--- a/filter_memory_leak.sh
+++ b/filter_memory_leak.sh
@@ -19,7 +19,7 @@ echo "Building all required containers"
 ( cd apps/filter-memory-leak// && docker build -t leaker . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml up -d
+docker compose -f apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml up -d
 
 wait_weaviate
 

--- a/geo_crash.sh
+++ b/geo_crash.sh
@@ -21,7 +21,7 @@ echo "Building all required containers"
 ( cd apps/geo-crash/ && docker build -t geo_crash . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/import_while_crashing.sh
+++ b/import_while_crashing.sh
@@ -24,7 +24,7 @@ echo "Building all required containers"
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
@@ -48,7 +48,7 @@ if ! docker run \
   --network host \
   -t importer; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose.yml logs weaviate
+  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
   exit 1
 fi
 

--- a/import_while_crashing_no_vector.sh
+++ b/import_while_crashing_no_vector.sh
@@ -24,7 +24,7 @@ echo "Building all required containers"
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
@@ -47,7 +47,7 @@ if ! docker run \
   --network host \
   -t importer-no-vector; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose.yml logs weaviate
+  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
   exit 1
 fi
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -19,7 +19,7 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker container rm -f ref-importer &>/dev/null && echo 'Deleted container ref-importer'
 }
@@ -42,7 +42,7 @@ if ! docker run \
   --network host \
   -t ref-importer python3 run.py; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml logs --tail 100
+  docker compose -f apps/weaviate/docker-compose-replication.yml logs --tail 100
   shutdown
   exit 1
 fi

--- a/multi_tenancy_activate_deactivate.sh
+++ b/multi_tenancy_activate_deactivate.sh
@@ -21,9 +21,9 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Showing logs..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker container rm -f multi-tenancy-activate-deactivate &>/dev/null && echo 'Deleted container multi-tenancy-activate-deactivate'
 }

--- a/multi_tenancy_concurrent_importing.sh
+++ b/multi_tenancy_concurrent_importing.sh
@@ -22,9 +22,9 @@ function wait_weaviate() {
 function shutdown() {
   echo "Cleaning up ressources..."
   rm -rf apps/weaviate/data-node-* || true
-  docker-compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
-  docker-compose -f apps/multi-tenancy-concurrent-imports/docker-compose-importers.yml down --remove-orphans
+  docker compose -f apps/multi-tenancy-concurrent-imports/docker-compose-importers.yml down --remove-orphans
 }
 trap 'shutdown; exit 1' SIGINT ERR
 

--- a/read_repair.sh
+++ b/read_repair.sh
@@ -46,7 +46,7 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 echo "Done generating."
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -58,29 +58,29 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # ADD objects with one node down, consistency level QUORUM
 echo "Killing node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
 sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name importer_additional -t importer_additional; then
   echo "All objects added with consistency level QUORUM with one node down".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # Restart dead node, read objects with consistency level ALL
 echo "Restart node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
 wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_read_repair -t cluster_read_repair; then
   echo "All objects read with consistency level ALL after weaviate-node-3 restarted".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 

--- a/replication_importing_while_crashing.sh
+++ b/replication_importing_while_crashing.sh
@@ -21,7 +21,7 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
   docker container rm -f killer  &>/dev/null && echo 'Deleted container killer'
@@ -34,7 +34,7 @@ echo "Building all required containers"
 
 echo "Starting Weaviate..."
 
-docker-compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -47,7 +47,7 @@ if ! docker run \
   --name importer \
   -t importer python3 run.py --action schema; then
   echo "Could not apply schema"
-  docker-compose -f apps/weaviate/docker-compose.yml logs
+  docker compose -f apps/weaviate/docker-compose.yml logs
   exit 1
 fi
 
@@ -68,7 +68,7 @@ if ! docker run \
   --network host \
   -t importer python3 run.py --action import; then
   echo "Importer failed, printing latest Weaviate logs..."
-  docker-compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 

--- a/replication_tunable_consistency.sh
+++ b/replication_tunable_consistency.sh
@@ -50,7 +50,7 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 echo "Done generating."
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -62,54 +62,54 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # PATCH objects with one node down, consistency level QUORUM
 echo "Killing node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
 sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name patcher -t patcher; then
   echo "All objects patched with consistency level QUORUM with one node down".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # Restart dead node, read objects with consistency level QUORUM
 echo "Restart node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
 wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_one_node_down -t cluster_one_node_down; then
   echo "All objects read with consistency level QUORUM after weaviate-node-3 restarted".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # PUT objects with only one node remaining, consistency level ONE
 echo "Killing node 2"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-2
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-2
 echo "Killing node 3"
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
 sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name updater -t updater; then
   echo "All objects updated with consistency level ONE with only weaviate-node-1 up".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
 # Restart dead nodes, read objects with consistency level ALL
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-2
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-2
 wait_weaviate 8081
-docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
 wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_one_node_remaining -t cluster_one_node_remaining; then
   echo "All objects read with consistency level ALL after weaviate-node-2 and weaviate-node-3 restarted".
 else
-  docker-compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 

--- a/rest_patch_stops_working_after_restart.sh
+++ b/rest_patch_stops_working_after_restart.sh
@@ -19,7 +19,7 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate/docker-compose.yml down --remove-orphans
+  docker compose -f apps/weaviate/docker-compose.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker rm -f rest-patch-stops-working-after-restart
 }
@@ -29,7 +29,7 @@ echo "Building all required containers"
 ( cd apps/rest-patch-stops-working-after-restart/ && docker build -t rest-patch-stops-working-after-restart . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 
@@ -37,8 +37,8 @@ echo "Run consecutive update operations"
 docker run --network host -t rest-patch-stops-working-after-restart python3 rest-patch-stops-working-after-restart.py
 
 echo "Restart Weaviate..."
-docker-compose -f apps/weaviate/docker-compose.yml stop
-docker-compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f apps/weaviate/docker-compose.yml stop
+docker compose -f apps/weaviate/docker-compose.yml up -d
 
 wait_weaviate
 

--- a/segfault_batch_ref.sh
+++ b/segfault_batch_ref.sh
@@ -19,7 +19,7 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker container rm -f segfault_batch_ref &>/dev/null && echo 'Deleted container segfault_batch_ref'
 }
@@ -29,11 +29,11 @@ echo "Building all required containers"
 ( cd apps/segfault-on-batch-ref/ && docker build -t segfault_batch_ref . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
 wait_weaviate
 
 function dump_logs() {
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
 }
 
 trap 'dump_logs' ERR

--- a/segfault_filtered_vector_search.sh
+++ b/segfault_filtered_vector_search.sh
@@ -19,7 +19,7 @@ function wait_weaviate() {
 
 function shutdown() {
   echo "Cleaning up ressources..."
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
   docker container rm -f segfault_filtered_vector_search &>/dev/null && echo 'Deleted container segfault_filtered_vector_search'
   for i in {1..3}; do
@@ -32,12 +32,12 @@ echo "Building all required containers"
 ( cd apps/segfault-on-filtered-vector-search/ && docker build -t segfault_filtered_vector_search . )
 
 echo "Starting Weaviate..."
-docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
 
 wait_weaviate
 
 function dump_logs() {
-  docker-compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
 }
 
 trap 'dump_logs' ERR


### PR DESCRIPTION
Docker compose v1 has been depreacted from Github runners (https://github.com/actions/runner-images/issues/9557) and it's usage is ending up in the following error:
docker-compose: command not found

Replacing it in all pipelines by the v2 alternative, docker compose.