### PR TITLE
cost: ignore running pipeline on main branches after merge

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -8,6 +8,9 @@ on:
         type: string
         required: true
   push:
+    branches-ignore:
+      - main
+      - pipeline/**
   schedule:
     - cron: '0 0 */2 * *'
 


### PR DESCRIPTION
we have now 
 - custom runs from the UI
 - runs on push on an open PR 
 - cron runners 
 
this PR disable running on merging to main branches `main` and `pipeline/*` in order to save costs given that the PR will be ran before merging
