### PR TITLE
refact: utlize wait and shutdown shell , normalize tests and docker comp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,17 @@
 workdir/
 weaviate-data/
 datasets/
-results/
+results/*
 logs/
 apps/**/vendor/**
 .DS_Store
 
+apps/weaviate/data*/
+apps/weaviate/backups*/
+
+
 # IDE files
-.idea/
-.vscode/
-.venv/
-__pycache__
+**/.idea/
+**/.vscode/
+**/.venv/
+**/__pycache__*/

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -2,10 +2,23 @@
 
 set -e
 
-source common.sh
-
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}
+
+function wait_weaviate() {
+  echo "Wait for Weaviate to be ready"
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
+      echo "Weaviate is ready"
+      return 0
+    fi
+
+    echo "Weaviate is not ready, trying again in 1s"
+    sleep 1
+  done
+  echo "ERROR: Weaviate is not ready after 120s"
+  exit 1
+}
 
 echo "Building all required containers"
 ( cd apps/ann-benchmarks/ && docker build -t ann_benchmarks . )

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-
 set -e
-
-source common.sh
 
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -3,23 +3,10 @@
 
 set -e
 
+source common.sh
+
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
 
 echo "Building all required containers"
 ( cd apps/ann-benchmarks/ && docker build -t ann_benchmarks . )
@@ -63,3 +50,4 @@ docker run --network host -t -v "$PWD/datasets:/datasets" \
 
 
 echo "Passed!"
+shutdown

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -50,4 +50,3 @@ docker run --network host -t -v "$PWD/datasets:/datasets" \
 
 
 echo "Passed!"
-shutdown

--- a/ann_benchmark.sh
+++ b/ann_benchmark.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source common.sh
+
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}
 

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source common.sh
-
 MACHINE_TYPE="${MACHINE_TYPE:-"m6i.2xlarge"}"
 CLOUD_PROVIDER="aws"
 OS="ubuntu-2204"

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source common.sh
+
 MACHINE_TYPE="${MACHINE_TYPE:-"m6i.2xlarge"}"
 CLOUD_PROVIDER="aws"
 OS="ubuntu-2204"
@@ -77,9 +79,3 @@ scp -i "${key_id}.pem" -r ann_benchmark.sh "$ssh_addr:~"
 ssh -i "${key_id}.pem" $ssh_addr -- "DATASET=$dataset DISTANCE=$distance REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
 mkdir -p results
 scp -i "${key_id}.pem" -r "$ssh_addr:~/results/*.json" results/
-
-
-
-
-
-

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source common.sh
-
 ZONE=${ZONE:-"us-central1-a"}
 MACHINE_TYPE=${MACHINE_TYPE:-"n2-standard-8"}
 CLOUD_PROVIDER="gcp"

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source common.sh
+
 ZONE=${ZONE:-"us-central1-a"}
 MACHINE_TYPE=${MACHINE_TYPE:-"n2-standard-8"}
 CLOUD_PROVIDER="gcp"
@@ -31,9 +33,3 @@ gcloud compute scp --zone $ZONE --recurse ann_benchmark.sh "$instance:~"
 gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE REQUIRED_RECALL=$REQUIRED_RECALL WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark.sh"
 mkdir -p results
 gcloud compute scp --zone $ZONE --recurse "$instance:~/results/*.json" results/
-
-
-
-
-
-

--- a/ann_benchmark_quantization.sh
+++ b/ann_benchmark_quantization.sh
@@ -52,4 +52,3 @@ docker run --network host -t -v "$PWD/datasets:/datasets" \
   ann_benchmarks python3 analyze.py
 
 echo "Passed!"
-shutdown

--- a/ann_benchmark_quantization.sh
+++ b/ann_benchmark_quantization.sh
@@ -2,24 +2,11 @@
 
 set -e
 
+source common.sh
+
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}
 quantization=${QUANTIZATION:-"none"}
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
 
 echo "Building all required containers"
 ( cd apps/ann-benchmarks/ && docker build -t ann_benchmarks . )
@@ -65,3 +52,4 @@ docker run --network host -t -v "$PWD/datasets:/datasets" \
   ann_benchmarks python3 analyze.py
 
 echo "Passed!"
+shutdown

--- a/ann_benchmark_quantization.sh
+++ b/ann_benchmark_quantization.sh
@@ -2,11 +2,25 @@
 
 set -e
 
-source common.sh
-
 dataset=${DATASET:-"sift-128-euclidean"}
 distance=${DISTANCE:-"l2-squared"}
 quantization=${QUANTIZATION:-"none"}
+
+
+function wait_weaviate() {
+  echo "Wait for Weaviate to be ready"
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
+      echo "Weaviate is ready"
+      return 0
+    fi
+
+    echo "Weaviate is not ready, trying again in 1s"
+    sleep 1
+  done
+  echo "ERROR: Weaviate is not ready after 120s"
+  exit 1
+}
 
 echo "Building all required containers"
 ( cd apps/ann-benchmarks/ && docker build -t ann_benchmarks . )

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source common.sh
-
 MACHINE_TYPE="${MACHINE_TYPE:-"m6i.2xlarge"}"
 CLOUD_PROVIDER="aws"
 OS="ubuntu-2204"

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source common.sh
+
 MACHINE_TYPE="${MACHINE_TYPE:-"m6i.2xlarge"}"
 CLOUD_PROVIDER="aws"
 OS="ubuntu-2204"
@@ -77,9 +79,3 @@ scp -i "${key_id}.pem" -r ann_benchmark_quantization.sh "$ssh_addr:~"
 ssh -i "${key_id}.pem" $ssh_addr -- "DATASET=$dataset DISTANCE=$distance REQUIRED_RECALL=$REQUIRED_RECALL QUANTIZATION=$QUANTIZATION WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_quantization.sh"
 mkdir -p results
 scp -i "${key_id}.pem" -r "$ssh_addr:~/results/*.json" results/
-
-
-
-
-
-

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+source common.sh
+
 ZONE=${ZONE:-"us-central1-a"}
 MACHINE_TYPE=${MACHINE_TYPE:-"n2-standard-8"}
 export CLOUD_PROVIDER="gcp"
@@ -31,9 +33,3 @@ gcloud compute scp --zone $ZONE --recurse ann_benchmark_quantization.sh "$instan
 gcloud compute ssh --zone $ZONE $instance -- "DATASET=$DATASET DISTANCE=$DISTANCE REQUIRED_RECALL=$REQUIRED_RECALL QUANTIZATION=$QUANTIZATION WEAVIATE_VERSION=$WEAVIATE_VERSION MACHINE_TYPE=$MACHINE_TYPE CLOUD_PROVIDER=$CLOUD_PROVIDER OS=$OS bash ann_benchmark_quantization.sh"
 mkdir -p results
 gcloud compute scp --zone $ZONE --recurse "$instance:~/results/*.json" results/
-
-
-
-
-
-

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-source common.sh
-
 ZONE=${ZONE:-"us-central1-a"}
 MACHINE_TYPE=${MACHINE_TYPE:-"n2-standard-8"}
 export CLOUD_PROVIDER="gcp"

--- a/apps/ann-benchmarks-results/.gitignore
+++ b/apps/ann-benchmarks-results/.gitignore
@@ -1,2 +1,0 @@
-results
-output

--- a/apps/ann-benchmarks/.gitignore
+++ b/apps/ann-benchmarks/.gitignore
@@ -1,2 +1,0 @@
-__pycache__*
-results/*

--- a/apps/replicated_import_with_backup/docker-compose.yml
+++ b/apps/replicated_import_with_backup/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      - ./../../weaviate-data/backups-s3:/data
+      - "$PWD/apps/weaviate/backups-s3:/data"
     environment:
       MINIO_ROOT_USER: 'aws_access_key'
       MINIO_ROOT_PASSWORD: 'aws_secret_key'

--- a/apps/upgrade-journey-raft/.gitignore
+++ b/apps/upgrade-journey-raft/.gitignore
@@ -1,2 +1,0 @@
-.venv/
-__pycache__/

--- a/apps/upgrade-journey/.gitignore
+++ b/apps/upgrade-journey/.gitignore
@@ -1,2 +1,0 @@
-data/
-vendor/

--- a/apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml
+++ b/apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml
@@ -14,7 +14,7 @@ services:
     - 8080:8080
     - 6060:6060
     volumes:
-    - "$PWD/weaviate-data:/var/lib/weaviate"
+    - "$PWD/apps/weaviate/data:/var/lib/weaviate"
     environment:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER: 2

--- a/apps/weaviate-no-restart-on-crash/docker-compose.yml
+++ b/apps/weaviate-no-restart-on-crash/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     - 50051:50051
     - 2112:2112
     volumes:
-    - "$PWD/weaviate-data:/var/lib/weaviate"
+    - "$PWD/apps/weaviate/data:/var/lib/weaviate"
     environment:
       - PERSISTENCE_DATA_PATH
       - PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS

--- a/apps/weaviate/.gitignore
+++ b/apps/weaviate/.gitignore
@@ -1,2 +1,0 @@
-data*/
-backups*/

--- a/apps/weaviate/docker-compose-backup.yml
+++ b/apps/weaviate/docker-compose-backup.yml
@@ -111,7 +111,7 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      - ./backups-s3:/data
+      - "$PWD/apps/weaviate/backups-s3:/var/lib/weaviate"
     environment:
       MINIO_ROOT_USER: 'aws_access_key'
       MINIO_ROOT_PASSWORD: 'aws_secret_key'

--- a/apps/weaviate/docker-compose-c11y.yml
+++ b/apps/weaviate/docker-compose-c11y.yml
@@ -13,7 +13,7 @@ services:
     - 8080:8080
     restart: on-failure:0
     volumes:
-      - ./data:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data:/var/lib/weaviate"
     environment:
       CONTEXTIONARY_URL: contextionary:9999
       QUERY_DEFAULTS_LIMIT: 25

--- a/apps/weaviate/docker-compose-replication.yml
+++ b/apps/weaviate/docker-compose-replication.yml
@@ -16,7 +16,7 @@ services:
     - 50051:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-1:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data-node-1:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25
@@ -47,7 +47,7 @@ services:
     - 50052:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-2:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data-node-2:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25
@@ -78,8 +78,8 @@ services:
     - 6062:6060
     - 50053:50051
     restart: on-failure:0
-    volumes:
-      - ./data-node-3:/var/lib/weaviate
+    volumes:      
+    - "$PWD/apps/weaviate/data-node-3:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25

--- a/apps/weaviate/docker-compose-replication_single_voter.yml
+++ b/apps/weaviate/docker-compose-replication_single_voter.yml
@@ -16,7 +16,7 @@ services:
     - 50051:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-1:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data-node-1:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25
@@ -47,7 +47,7 @@ services:
     - 50052:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-2:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data-node-2:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25
@@ -79,7 +79,7 @@ services:
     - 50053:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-3:/var/lib/weaviate
+      - "$PWD/apps/weaviate/data-node-3:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25

--- a/apps/weaviate/docker-compose-single-voter-without-node-name.yml
+++ b/apps/weaviate/docker-compose-single-voter-without-node-name.yml
@@ -16,7 +16,7 @@ services:
     - 50051:50051
     restart: on-failure:0
     volumes:
-      - ./data-node-1:/var/lib/weaviate
+    - "$PWD/apps/weaviate/data:/var/lib/weaviate"
     environment:
       LOG_LEVEL: 'debug'
       QUERY_DEFAULTS_LIMIT: 25

--- a/apps/weaviate/docker-compose.yml
+++ b/apps/weaviate/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     - 50051:50051
     restart: on-failure:0
     volumes:
-      - ./data:/var/lib/weaviate
+    - "$PWD/apps/weaviate/data:/var/lib/weaviate"
     environment:
       QUERY_DEFAULTS_LIMIT: 25
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'

--- a/backup_and_flush.sh
+++ b/backup_and_flush.sh
@@ -2,18 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      break
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/backup-and-flush/ && docker build -t backup_and_flush . )
@@ -27,3 +16,4 @@ echo "Perform a backup and verify that flushing is restablished after the backup
 docker run --network host -v ./apps/weaviate/data:/data -t backup_and_flush python3 backup_and_flush.py
 
 echo "Passed!"
+shutdown

--- a/backup_and_restore_crud.sh
+++ b/backup_and_restore_crud.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud . )
@@ -29,3 +16,4 @@ echo "Run backup and restore CRUD operations"
 docker run --network host -t backup_and_restore_crud python3 backup_and_restore_crud.py
 
 echo "Passed!"
+shutdown

--- a/batch_import_many_classes.sh
+++ b/batch_import_many_classes.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/batch-import-many-classes/ && docker build -t batch_import_many_classes . )
@@ -32,3 +19,4 @@ echo "Run class creation and deletion in the foreground - fail on timeout"
 docker run --network host -t batch_import_many_classes python3 many_classes.py
 
 echo "Passed!"
+shutdown

--- a/batch_insert_mismatch.sh
+++ b/batch_insert_mismatch.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/batch-insert-mismatch/ && docker build -t batch-insert-mismatch . )
@@ -29,3 +16,4 @@ echo "Run consecutive create and delete operations"
 docker run --network host -t batch-insert-mismatch python3 batch-insert-mismatch.py
 
 echo "Passed!"
+shutdown

--- a/bm25_corruption.sh
+++ b/bm25_corruption.sh
@@ -2,22 +2,9 @@
 
 set -e
 
-SIZE=600000
+source common.sh
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+SIZE=600000 
 
 echo "Building all required containers"
 ( cd apps/bm25-corruption/ && docker build -t importer . )
@@ -43,3 +30,4 @@ docker run \
   importer sh -c "python3 /app/run.py --mode=docker"
 
 echo "Passed!"
+shutdown

--- a/common.sh
+++ b/common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+function wait_weaviate() {
+  local port="${1:-8080}" # Set default port to 8080 if $1 is not provided
+  echo "Wait for Weaviate to be ready"
+  for _ in {1..120}; do
+    if curl -sf -o /dev/null localhost:$port/v1/.well-known/ready; then
+      echo "Weaviate is ready"
+      return 0
+    fi
+
+    echo "Weaviate is not ready on $port, trying again in 1s"
+    sleep 1
+  done
+  echo "ERROR: Weaviate is not ready in port ${port} after 120s"
+  exit 1
+}
+
+function shutdown() { 
+  echo "Cleaning up resources..."  
+  container_count=$(docker container ls -aq | wc -l)
+  if [ "$container_count" -gt 0 ]; then
+    # Place the command you want to execute here
+    echo "There are $container_count containers."
+    docker container rm -f $(docker container ls -aq)
+  fi
+    
+  compose_files=$(ls apps/weaviate/docker-compose-*.yml)
+  for file in $compose_files; do
+    docker compose -f "$file" down --remove-orphans
+  done
+  
+  rm -rf apps/weaviate/data* || true    
+  rm -rf workdir
+}
+trap 'shutdown; exit 1' SIGINT ERR

--- a/common.sh
+++ b/common.sh
@@ -51,4 +51,7 @@ function shutdown() {
   rm -rf apps/weaviate/data* || true    
   rm -rf workdir
 }
+
 trap 'logs; shutdown; exit 1' SIGINT ERR
+
+trap '[[ $? -eq 1 ]] && logs; shutdown' EXIT

--- a/compaction_roaringset.sh
+++ b/compaction_roaringset.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/compaction-roaringset/ && docker build -t compaction-roaringset . )
@@ -35,3 +22,4 @@ echo "Run create/delete objects script designed to panic on compacting roaringse
 docker run --network host -t compaction-roaringset python3 run.py
 
 echo "Passed!"
+shutdown

--- a/compare_recall_after_restart.sh
+++ b/compare_recall_after_restart.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/recall/ && docker build -t recall . )
@@ -49,3 +36,6 @@ wait_weaviate
 
 echo "Check Recall again"
 docker run --network host -v "$PWD/workdir/:/app/data" -t recall-checker
+
+echo "Passed!"
+shutdown

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/compare-rest-graphql/ && docker build -t compare-rest-graphql . )
@@ -54,3 +41,4 @@ echo "Script completed successfully, stop killer"
 docker rm -f killer
 
 echo "Passed!"
+shutdown

--- a/concurrent_inverted_index_read_write.sh
+++ b/concurrent_inverted_index_read_write.sh
@@ -2,23 +2,9 @@
 
 set -e
 
-SIZE=100000
+source common.sh
 
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+SIZE=100000 
 
 echo "Building all required containers"
 ( cd apps/importer-concurrent-inverted-index/ && docker build -t importer . )
@@ -43,3 +29,4 @@ if ! docker run \
 fi
 
 echo "Passed!"
+shutdown

--- a/concurrent_inverted_index_read_write.sh
+++ b/concurrent_inverted_index_read_write.sh
@@ -23,8 +23,7 @@ if ! docker run \
   -e 'ORIGIN=http://localhost:8080' \
   --network host \
   -t importer; then
-  echo "Importer failed, printing latest Weaviate logs..."
-  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
+  echo "Importer failed, printing latest Weaviate logs..."  
   exit 1
 fi
 

--- a/consecutive_create_and_update_operations.sh
+++ b/consecutive_create_and_update_operations.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e 
+set -e
 
 source common.sh
 

--- a/consecutive_create_and_update_operations.sh
+++ b/consecutive_create_and_update_operations.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
 
-set -e
+set -e 
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/consecutive_create_and_update_operations/ && docker build -t consecutive_create_and_update_operations . )
@@ -29,3 +16,4 @@ echo "Run consecutive create and update operations"
 docker run --network host -t consecutive_create_and_update_operations python3 consecutive_create_and_update_operations.py
 
 echo "Passed!"
+shutdown

--- a/counting_while_compacting.sh
+++ b/counting_while_compacting.sh
@@ -25,4 +25,3 @@ docker run --network host -e ORIGIN=http://localhost:8080 -t counting-while-comp
 
 echo "Passed!"
 shutdown
-

--- a/counting_while_compacting.sh
+++ b/counting_while_compacting.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/counting-while-compacting/ && docker build -t counting-while-compacting . )
@@ -37,3 +24,5 @@ echo "Run import script that imports, deletes and counts objects"
 docker run --network host -e ORIGIN=http://localhost:8080 -t counting-while-compacting
 
 echo "Passed!"
+shutdown
+

--- a/delete_and_recreate_class.sh
+++ b/delete_and_recreate_class.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/delete_and_recreate && docker build -t delete_and_recreate . )
@@ -29,3 +16,4 @@ echo "Run consecutive create and update operations"
 docker run --network host -t delete_and_recreate python3 delete_and_recreate.py
 
 echo "Passed!"
+shutdown

--- a/deletes_with_node_out_of_sync.sh
+++ b/deletes_with_node_out_of_sync.sh
@@ -37,7 +37,6 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -58,22 +57,19 @@ wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name check_objects_in_nodes -t check_objects_in_nodes; then
   echo "tenant2 objects are present in Node 1 but not in Node 3, as it was down."
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
-  exit 1
+    exit 1
 fi
 
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name deleter -t deleter; then
   echo "All tenant2 objects deleted with consistency level ONE."
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
-  exit 1
+    exit 1
 fi
 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name check_objects_deleted -t check_objects_deleted; then
   echo "tenant2 objects were deleted from all nodes."
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
-  exit 1
+    exit 1
 fi
 
 echo "Success!"

--- a/deletes_with_node_out_of_sync.sh
+++ b/deletes_with_node_out_of_sync.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/deletes_with_node_out_of_sync/ && docker build --build-arg APP_NAME=generator -t generator . )
@@ -26,22 +13,6 @@ echo "Building all required containers"
 ( cd apps/deletes_with_node_out_of_sync/ && docker build --build-arg APP_NAME=cluster_healthy -t cluster_healthy . )
 ( cd apps/deletes_with_node_out_of_sync/ && docker build --build-arg APP_NAME=check_objects_in_nodes -t check_objects_in_nodes . )
 ( cd apps/deletes_with_node_out_of_sync/ && docker build --build-arg APP_NAME=check_objects_deleted -t check_objects_deleted . )
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f generator &>/dev/null && echo 'Deleted container generator'
-  docker container rm -f regenerator &>/dev/null && echo 'Deleted container regenerator'
-  docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
-  docker container rm -f reimporter &>/dev/null && echo 'Deleted container reimporter'
-  docker container rm -f deleter &>/dev/null && echo 'Deleted container deleter'
-  docker container rm -f check_objects_in_nodes &>/dev/null && echo 'Deleted container check_objects_in_nodes'
-  docker container rm -f check_objects_deleted &>/dev/null && echo 'Deleted container check_objects_deleted'
-  docker container rm -f cluster_healthy &>/dev/null && echo 'Deleted container cluster_healthy'
-  rm -rf workdir
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 rm -rf workdir
 mkdir workdir
@@ -104,3 +75,6 @@ else
   docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
+
+echo "Success!"
+shutdown

--- a/filter_memory_leak.sh
+++ b/filter_memory_leak.sh
@@ -2,18 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080; then
-      echo "Weaviate is ready"
-      break
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/filter-memory-leak// && docker build -t leaker . )
@@ -27,3 +16,4 @@ echo "Run backup and restore CRUD operations"
 docker run --network host -t leaker python3 run.py
 
 echo "Passed!"
+shutdown

--- a/geo_crash.sh
+++ b/geo_crash.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/geo-crash/ && docker build -t geo_crash . )
@@ -29,3 +16,4 @@ echo "Import geo props with many duplicates (lots of hnsw commit logging)"
 docker run --network host -t geo_crash python3 run.py
 
 echo "Passed!"
+shutdown

--- a/goroutine_leak_on_class_delete.sh
+++ b/goroutine_leak_on_class_delete.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/goroutine-leak-on-class-delete/ && docker build -t goroutine-test-script . )
@@ -29,3 +16,6 @@ wait_weaviate 8080
 
 echo "Run test script"
 docker run --network host -t goroutine-test-script python3 run.py
+
+echo "Passed!"
+shutdown

--- a/import_while_crashing.sh
+++ b/import_while_crashing.sh
@@ -34,8 +34,7 @@ if ! docker run \
   -e 'ORIGIN=http://localhost:8080' \
   --network host \
   -t importer; then
-  echo "Importer failed, printing latest Weaviate logs..."
-  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
+  echo "Importer failed, printing latest Weaviate logs..."  
   exit 1
 fi
 

--- a/import_while_crashing.sh
+++ b/import_while_crashing.sh
@@ -2,22 +2,9 @@
 
 set -e
 
+source common.sh
+
 SIZE=600000
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
 
 echo "Building all required containers"
 ( cd apps/importer/ && docker build -t importer . )
@@ -84,3 +71,4 @@ if [ $attempt -gt $retries ]; then
 fi
 
 echo "Passed!"
+shutdown

--- a/import_while_crashing_no_vector.sh
+++ b/import_while_crashing_no_vector.sh
@@ -2,22 +2,9 @@
 
 set -e
 
+source common.sh
+
 SIZE=100000
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
 
 echo "Building all required containers"
 ( cd apps/importer-no-vector-index/ && docker build -t importer-no-vector . )
@@ -83,3 +70,4 @@ if [ $attempt -gt $retries ]; then
 fi
 
 echo "Passed!"
+shutdown

--- a/import_while_crashing_no_vector.sh
+++ b/import_while_crashing_no_vector.sh
@@ -33,9 +33,8 @@ if ! docker run \
   -e 'ORIGIN=http://localhost:8080' \
   --network host \
   -t importer-no-vector; then
-  echo "Importer failed, printing latest Weaviate logs..."
-  docker compose -f apps/weaviate/docker-compose.yml logs weaviate
-  exit 1
+  echo "Importer failed, printing latest Weaviate logs..."  
+    exit 1
 fi
 
 echo "Import completed successfully, stop killer"
@@ -66,7 +65,7 @@ done
 
 if [ $attempt -gt $retries ]; then
   echo "Failed to validate object count after $retries attempts"
-  exit 1
+    exit 1
 fi
 
 echo "Passed!"

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -20,9 +20,7 @@ if ! docker run \
   --name ref-importer \
   --network host \
   -t ref-importer python3 run.py; then
-  echo "Importer failed, printing latest Weaviate logs..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml logs --tail 100
-  shutdown
+  echo "Importer failed, printing latest Weaviate logs..."  
   exit 1
 fi
 
@@ -31,7 +29,6 @@ errors="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>
 if (( $warnings > 0 )); then
   docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error
   echo "too many errors ($errors)"
-  shutdown
   exit 1
 fi
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -2,28 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f ref-importer &>/dev/null && echo 'Deleted container ref-importer'
-}
-trap 'shutdown; exit 1' SIGINT ERR
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/multi-node-references && docker build -t ref-importer . )
@@ -56,5 +35,5 @@ if (( $warnings > 0 )); then
   exit 1
 fi
 
-echo "No errors. Passed."
+echo "Passed!"
 shutdown

--- a/multi_tenancy_activate_deactivate.sh
+++ b/multi_tenancy_activate_deactivate.sh
@@ -2,32 +2,10 @@
 
 set -e
 
+source common.sh
+
 git submodule update --init --remote --recursive
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Showing logs..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f multi-tenancy-activate-deactivate &>/dev/null && echo 'Deleted container multi-tenancy-activate-deactivate'
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 echo "Starting Weaviate..."
 docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3

--- a/multi_tenancy_concurrent_importing.sh
+++ b/multi_tenancy_concurrent_importing.sh
@@ -2,31 +2,10 @@
 
 set -e
 
+source common.sh
+
 git submodule update --init --remote --recursive
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  rm -rf apps/weaviate/data-node-* || true
-  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker compose -f apps/multi-tenancy-concurrent-imports/docker-compose-importers.yml down --remove-orphans
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 echo "Starting Weaviate..."
 docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3

--- a/read_repair.sh
+++ b/read_repair.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/read_repair/ && docker build --build-arg APP_NAME=generator -t generator . )
@@ -24,18 +11,6 @@ echo "Building all required containers"
 ( cd apps/read_repair/ && docker build --build-arg APP_NAME=cluster_healthy -t cluster_healthy . )
 ( cd apps/read_repair/ && docker build --build-arg APP_NAME=cluster_read_repair -t cluster_read_repair . )
 
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f generator &>/dev/null && echo 'Deleted container generator'
-  docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
-  docker container rm -f importer_additional &>/dev/null && echo 'Deleted container importer_additional'
-  docker container rm -f cluster_read_repair &>/dev/null && echo 'Deleted container cluster_read_repair'
-  docker container rm -f cluster_healthy &>/dev/null && echo 'Deleted container cluster_healthy'
-  rm -rf workdir
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 rm -rf workdir
 mkdir workdir
@@ -58,7 +33,6 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -69,7 +43,6 @@ sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name importer_additional -t importer_additional; then
   echo "All objects added with consistency level QUORUM with one node down".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -80,7 +53,6 @@ wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_read_repair -t cluster_read_repair; then
   echo "All objects read with consistency level ALL after weaviate-node-3 restarted".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 

--- a/replication_importing_while_crashing.sh
+++ b/replication_importing_while_crashing.sh
@@ -2,31 +2,9 @@
 
 set -e
 
+source common.sh
+
 SIZE=300000
-
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
-  docker container rm -f killer  &>/dev/null && echo 'Deleted container killer'
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 echo "Building all required containers"
 ( cd apps/replicated-import/ && docker build -t importer . )
@@ -74,3 +52,5 @@ fi
 
 echo "Import completed successfully, stop killer"
 docker rm -f killer
+echo "Passed!"
+shutdown

--- a/replication_importing_while_crashing.sh
+++ b/replication_importing_while_crashing.sh
@@ -24,8 +24,7 @@ if ! docker run \
   --rm \
   --name importer \
   -t importer python3 run.py --action schema; then
-  echo "Could not apply schema"
-  docker compose -f apps/weaviate/docker-compose.yml logs
+  echo "Could not apply schema"  
   exit 1
 fi
 
@@ -45,8 +44,7 @@ if ! docker run \
   -e 'ORIGIN=http://localhost:8080' \
   --network host \
   -t importer python3 run.py --action import; then
-  echo "Importer failed, printing latest Weaviate logs..."
-  docker compose -f apps/weaviate/docker-compose-replication.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
+  echo "Importer failed, printing latest Weaviate logs..."  
   exit 1
 fi
 

--- a/replication_importing_with_backup.sh
+++ b/replication_importing_with_backup.sh
@@ -1,28 +1,8 @@
 #!/bin/bash
 
+set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready on $1"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/replicated_import_with_backup/docker-compose.yml up remove-s3-bucket
-  docker compose -f apps/replicated_import_with_backup/docker-compose.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-}
-trap 'shutdown; exit 1' SIGINT ERR
+source common.sh
 
 function compose_exit_code() {
   echo $(docker inspect $1 --format='{{.State.ExitCode}}')
@@ -49,8 +29,8 @@ docker compose -f apps/replicated_import_with_backup/docker-compose.yml up \
 
 if [ $(compose_exit_code importer-schema-node-1) -ne 0 ]; then
   echo "Could not apply schema"
-  shutdown
-  exit 1
+  # shutdown
+  # exit 1
 fi
 
 echo "Batch import to 2 nodes + parallel backup..."
@@ -73,9 +53,9 @@ if [[ $exit_code_imp_1 != 0 && $exit_code_imp_1 != 137 ]] || \
     [[ $exit_code_imp_2 != 0 && $exit_code_imp_2 != 137 ]] || \
     [[ $exit_code_bck != 0 && $exit_code_bck != 137 ]]; then
   echo "Could not import/backup"
-  shutdown
-  exit 1
+  # shutdown
+  # exit 1
 fi
 
 echo "Passed!"
-shutdown
+# shutdown

--- a/replication_importing_with_backup.sh
+++ b/replication_importing_with_backup.sh
@@ -29,8 +29,7 @@ docker compose -f apps/replicated_import_with_backup/docker-compose.yml up \
 
 if [ $(compose_exit_code importer-schema-node-1) -ne 0 ]; then
   echo "Could not apply schema"
-  # shutdown
-  # exit 1
+  exit 1
 fi
 
 echo "Batch import to 2 nodes + parallel backup..."
@@ -53,9 +52,8 @@ if [[ $exit_code_imp_1 != 0 && $exit_code_imp_1 != 137 ]] || \
     [[ $exit_code_imp_2 != 0 && $exit_code_imp_2 != 137 ]] || \
     [[ $exit_code_bck != 0 && $exit_code_bck != 137 ]]; then
   echo "Could not import/backup"
-  # shutdown
-  # exit 1
+  exit 1
 fi
 
 echo "Passed!"
-# shutdown
+shutdown

--- a/replication_tunable_consistency.sh
+++ b/replication_tunable_consistency.sh
@@ -2,20 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/replication_tunable_consistency/ && docker build --build-arg APP_NAME=generator -t generator . )
@@ -25,21 +12,6 @@ echo "Building all required containers"
 ( cd apps/replication_tunable_consistency/ && docker build --build-arg APP_NAME=cluster_healthy -t cluster_healthy . )
 ( cd apps/replication_tunable_consistency/ && docker build --build-arg APP_NAME=cluster_one_node_down -t cluster_one_node_down . )
 ( cd apps/replication_tunable_consistency/ && docker build --build-arg APP_NAME=cluster_one_node_remaining -t cluster_one_node_remaining . )
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f generator &>/dev/null && echo 'Deleted container generator'
-  docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
-  docker container rm -f patcher &>/dev/null && echo 'Deleted container patcher'
-  docker container rm -f cluster_one_node_down &>/dev/null && echo 'Deleted container cluster_one_node_down'
-  docker container rm -f updater &>/dev/null && echo 'Deleted container updater'
-  docker container rm -f cluster_one_node_remaining &>/dev/null && echo 'Deleted container cluster_one_node_remaining'
-  docker container rm -f cluster_healthy &>/dev/null && echo 'Deleted container cluster_healthy'
-  rm -rf workdir
-}
-trap 'shutdown; exit 1' SIGINT ERR
 
 rm -rf workdir
 mkdir workdir
@@ -114,3 +86,4 @@ else
 fi
 
 echo "Success!"
+shutdown

--- a/replication_tunable_consistency.sh
+++ b/replication_tunable_consistency.sh
@@ -34,7 +34,6 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
   echo "All objects read with consistency level ONE".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -45,7 +44,6 @@ sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name patcher -t patcher; then
   echo "All objects patched with consistency level QUORUM with one node down".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -56,7 +54,6 @@ wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_one_node_down -t cluster_one_node_down; then
   echo "All objects read with consistency level QUORUM after weaviate-node-3 restarted".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -69,7 +66,6 @@ sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name updater -t updater; then
   echo "All objects updated with consistency level ONE with only weaviate-node-1 up".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 
@@ -81,7 +77,6 @@ wait_weaviate 8082
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_one_node_remaining -t cluster_one_node_remaining; then
   echo "All objects read with consistency level ALL after weaviate-node-2 and weaviate-node-3 restarted".
 else
-  docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml logs weaviate-node-1 weaviate-node-2 weaviate-node-3
   exit 1
 fi
 

--- a/rest_patch_stops_working_after_restart.sh
+++ b/rest_patch_stops_working_after_restart.sh
@@ -2,28 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker rm -f rest-patch-stops-working-after-restart
-}
-trap 'shutdown; exit 1' SIGINT ERR
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/rest-patch-stops-working-after-restart/ && docker build -t rest-patch-stops-working-after-restart . )

--- a/segfault_batch_ref.sh
+++ b/segfault_batch_ref.sh
@@ -2,28 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f segfault_batch_ref &>/dev/null && echo 'Deleted container segfault_batch_ref'
-}
-trap 'shutdown; exit 1' SIGINT ERR
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/segfault-on-batch-ref/ && docker build -t segfault_batch_ref . )

--- a/segfault_filtered_vector_search.sh
+++ b/segfault_filtered_vector_search.sh
@@ -2,31 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:8080/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready after 120s"
-  exit 1
-}
-
-function shutdown() {
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true
-  docker container rm -f segfault_filtered_vector_search &>/dev/null && echo 'Deleted container segfault_filtered_vector_search'
-  for i in {1..3}; do
-    docker container rm -f "segfault_filtered_vector_search-$i" &>/dev/null && echo "Deleted container segfault_filtered_vector_search-$i"
-  done
-}
-trap 'shutdown; exit 1' SIGINT ERR
+source common.sh
 
 echo "Building all required containers"
 ( cd apps/segfault-on-filtered-vector-search/ && docker build -t segfault_filtered_vector_search . )
@@ -55,3 +31,4 @@ echo "Run import script designed to lead to frequent hash prop compactions"
 docker run --network host --rm --name segfault_filtered_vector_search -t segfault_filtered_vector_search python3 run.py -a import
 
 echo "Passed!"
+shutdown

--- a/upgrade_single_node_journey.sh
+++ b/upgrade_single_node_journey.sh
@@ -2,34 +2,7 @@
 
 set -e
 
-function wait_weaviate() {
-  echo "Wait for Weaviate to be ready"
-  for _ in {1..120}; do
-    if curl -sf -o /dev/null localhost:$1/v1/.well-known/ready; then
-      echo "Weaviate is ready"
-      return 0
-    fi
-
-    echo "Weaviate is not ready on $1, trying again in 1s"
-    sleep 1
-  done
-  echo "ERROR: Weaviate is not ready in port ${1} after 120s"
-  exit 1
-}
-
-function shutdown() {  
-  echo "Cleaning up ressources..."
-  docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml down --remove-orphans
-  rm -rf apps/weaviate/data* || true  
-  docker container rm -f generator &>/dev/null && echo 'Deleted container generator'
-  docker container rm -f importer &>/dev/null && echo 'Deleted container importer'
-  docker container rm -f importer_additional &>/dev/null && echo 'Deleted container importer_additional'
-  docker container rm -f cluster_read_repair &>/dev/null && echo 'Deleted container cluster_read_repair'
-  docker container rm -f cluster_healthy &>/dev/null && echo 'Deleted container cluster_healthy'
-  rm -rf workdir
-}
-trap 'shutdown; exit 1' SIGINT ERR
-
+source common.sh
 
 function restart() {
   echo "Restarting node ..."

--- a/upgrade_single_node_journey.sh
+++ b/upgrade_single_node_journey.sh
@@ -18,7 +18,7 @@ function validateObjects() {
   if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
     echo "All objects read with consistency level ONE".
   else
-    docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml logs weaviate-node-1 
+    docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml logs weaviate-node-1
     exit 1
   fi
 }
@@ -61,9 +61,8 @@ restart
 
 echo "Import additional objects"
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name importer_additional -t importer_additional; then
-  echo "All objects added with consistency level ONE".
+  echo "All objects added with consistency level QUORUM with one node down".
 else
-  docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml logs weaviate-node-1
   exit 1
 fi
 


### PR DESCRIPTION
this PR 
- introduces `common.sh` file to utilize the `wait_weaviate()` and `shutdown()` shell functions  
- remove redundant impl. for wait_weaviate() and shutdown()
- unify the test docker volumes to be created and  cleaned after the test