### PR TITLE
disable running pipeline on pushs to save costs and time

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -11,11 +11,7 @@ on:
         description: "The weaviate max major version run tests against 1.24, 1.25, 1.26 etc. by default all will run"
         type: number
         default: 0
-        required: false
-  push:
-    branches-ignore:
-      - main
-      - pipeline/**
+        required: false  
   schedule:
     - cron: '0 0 */2 * *'
 


### PR DESCRIPTION
we have now 
- running via the GH UI workflow dispatcher 
- cron '0 0 */2 * *'

to save time and cost will disable the automatic runs  on pushing to branches 