### PR TITLE
Stabilize chaos-tests.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -435,7 +435,7 @@ jobs:
         run: ./replication_importing_with_backup.sh
   replication-tunable-consistency:
     name: Replication tunable consistency
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 60
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}

--- a/apps/debug-reindexing-endpoint/go.mod
+++ b/apps/debug-reindexing-endpoint/go.mod
@@ -1,6 +1,6 @@
-module github.com/semi-technologies/weaviate-chaos-engineering-reindexing
+module reindexing-endpoint
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/apps/debug-reindexing-endpoint/go.mod
+++ b/apps/debug-reindexing-endpoint/go.mod
@@ -1,6 +1,6 @@
 module reindexing-endpoint
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/stretchr/testify v1.9.0

--- a/apps/goroutine-leak-on-class-delete/run.py
+++ b/apps/goroutine-leak-on-class-delete/run.py
@@ -48,4 +48,4 @@ def mean(durs: [float]) -> float:
     return sum(durs) / len(durs)
 
 
-StressTest().run(iterations=20_000, start_checking=1000, rolling_average_count=250)
+StressTest().run(iterations=15_000, start_checking=1000, rolling_average_count=250)

--- a/apps/importer/app.go
+++ b/apps/importer/app.go
@@ -133,35 +133,39 @@ func (b *batch) send(client *http.Client, origin string) error {
 
 	req.Header.Add("content-type", "application/json")
 
+	const maxRetries = 100
+	const retryDelay = 1 * time.Second
+
 	var res *http.Response
-	attempt := 0
-	res, err = client.Do(req)
-	for err != nil {
-		fmt.Printf("attempt %d failed with %s, try again in 1s...\n", attempt, err)
-		time.Sleep(1 * time.Second)
 
-		r.Seek(0, 0)
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		res, err = client.Do(req)
 
-		if attempt == 100 {
-			log.Printf("abort after 100 retries")
-			return err
+		if err == nil && res != nil && res.StatusCode == 200 {
+			defer res.Body.Close()
+			io.ReadAll(res.Body)
+			return nil
 		}
 
-		attempt++
-		res, err = client.Do(req)
+		if attempt < maxRetries {
+			fmt.Printf("Attempt %d failed (error: %v). Retrying in 1s...\n", attempt, err)
+			time.Sleep(retryDelay)
+
+			r.Seek(0, 0)
+		} else {
+			fmt.Printf("Aborting after %d retries\n", maxRetries)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("request failed after %d retries: %v", maxRetries, err)
 	}
 
 	defer res.Body.Close()
 
-	if res.StatusCode != 200 {
-		msg, _ := io.ReadAll(res.Body)
+	msg, _ := io.ReadAll(res.Body)
+	return errors.Errorf("status %d: %s", res.StatusCode, string(msg))
 
-		return errors.Errorf("status %d: %s", res.StatusCode, string(msg))
-	}
-
-	io.ReadAll(res.Body)
-
-	return nil
 }
 
 func randomVector(dim int) []float32 {

--- a/apps/multi-tenancy-activate-deactivate/run.go
+++ b/apps/multi-tenancy-activate-deactivate/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -448,20 +449,11 @@ func test2() {
 		log.Printf("loop [%d] activating tenants created as inactive\n", l)
 
 		// activate created as inactive
-		err = client.Schema().TenantsUpdater().
-			WithClassName(classPizza).
-			WithTenants(coldBuf.WithStatus(models.TenantActivityStatusHOT)...).
-			Do(ctx)
+		err = updateTentantWithRetry(client, classPizza, coldBuf.WithStatus(models.TenantActivityStatusHOT))
 		requireNil(err)
-		err = client.Schema().TenantsUpdater().
-			WithClassName(classSoup).
-			WithTenants(coldBuf.WithStatus(models.TenantActivityStatusHOT)...).
-			Do(ctx)
+		err = updateTentantWithRetry(client, classSoup, coldBuf.WithStatus(models.TenantActivityStatusHOT))
 		requireNil(err)
-		err = client.Schema().TenantsUpdater().
-			WithClassName(classRisotto).
-			WithTenants(coldBuf.WithStatus(models.TenantActivityStatusHOT)...).
-			Do(ctx)
+		err = updateTentantWithRetry(client, classRisotto, coldBuf.WithStatus(models.TenantActivityStatusHOT))
 		requireNil(err)
 
 		// ==================================================================================
@@ -470,37 +462,19 @@ func test2() {
 
 		// deactivate and activate back again (x3)
 		for i := 0; i < 3; i++ {
-			err := client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusCOLD)...).
-				WithClassName(classPizza).
-				Do(ctx)
+			err := updateTentantWithRetry(client, classPizza, batchTenants.WithStatus(models.TenantActivityStatusCOLD))
 			requireNil(err)
-			err = client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusHOT)...).
-				WithClassName(classPizza).
-				Do(ctx)
+			err = updateTentantWithRetry(client, classPizza, batchTenants.WithStatus(models.TenantActivityStatusHOT))
 			requireNil(err)
 
-			err = client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusCOLD)...).
-				WithClassName(classSoup).
-				Do(ctx)
+			err = updateTentantWithRetry(client, classSoup, batchTenants.WithStatus(models.TenantActivityStatusCOLD))
 			requireNil(err)
-			err = client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusHOT)...).
-				WithClassName(classSoup).
-				Do(ctx)
+			err = updateTentantWithRetry(client, classSoup, batchTenants.WithStatus(models.TenantActivityStatusHOT))
 			requireNil(err)
 
-			err = client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusCOLD)...).
-				WithClassName(classRisotto).
-				Do(ctx)
+			err = updateTentantWithRetry(client, classRisotto, batchTenants.WithStatus(models.TenantActivityStatusCOLD))
 			requireNil(err)
-			err = client.Schema().TenantsUpdater().
-				WithTenants(batchTenants.WithStatus(models.TenantActivityStatusHOT)...).
-				WithClassName(classRisotto).
-				Do(ctx)
+			err = updateTentantWithRetry(client, classRisotto, batchTenants.WithStatus(models.TenantActivityStatusHOT))
 			requireNil(err)
 
 			log.Printf("loop [%d][%d] activated\n", l, i)
@@ -553,41 +527,24 @@ func test2() {
 				half := len(batch) / 2
 
 				// effectively activate and  populate 1st half
-				err = client.Schema().TenantsUpdater().
-					WithClassName(classPizza).
-					WithTenants(batch[:half].WithStatus(models.TenantActivityStatusHOT)...).
-					Do(ctx)
+				err = updateTentantWithRetry(client, classPizza, batch[:half].WithStatus(models.TenantActivityStatusHOT))
 				requireNil(err)
-				err = client.Schema().TenantsUpdater().
-					WithClassName(classSoup).
-					WithTenants(batch[:half].WithStatus(models.TenantActivityStatusHOT)...).
-					Do(ctx)
+				err = updateTentantWithRetry(client, classSoup, batch[:half].WithStatus(models.TenantActivityStatusHOT))
 				requireNil(err)
 
 				for i := 0; i < 3; i++ {
-					err := client.Schema().TenantsUpdater().
-						WithTenants(batch[:half].WithStatus(models.TenantActivityStatusCOLD)...).
-						WithClassName(classPizza).
-						Do(ctx)
+					err := updateTentantWithRetry(client, classPizza, batch[:half].WithStatus(models.TenantActivityStatusCOLD))
 					requireNil(err)
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[:half].WithStatus(models.TenantActivityStatusHOT)...).
-						WithClassName(classPizza).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classPizza, batch[:half].WithStatus(models.TenantActivityStatusHOT))
 					requireNil(err)
 
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[:half].WithStatus(models.TenantActivityStatusCOLD)...).
-						WithClassName(classSoup).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classSoup, batch[:half].WithStatus(models.TenantActivityStatusCOLD))
 					requireNil(err)
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[:half].WithStatus(models.TenantActivityStatusHOT)...).
-						WithClassName(classSoup).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classSoup, batch[:half].WithStatus(models.TenantActivityStatusHOT))
 					requireNil(err)
 
 					log.Printf("loop [%d][%d] batch [%d] activated\n", l, i, batchNum)
+
 				}
 
 				// ==================================================================================
@@ -604,40 +561,22 @@ func test2() {
 
 				// effectively deactivate 2nd half
 				for i := 0; i < 3; i++ {
-					err := client.Schema().TenantsUpdater().
-						WithTenants(batch[half:].WithStatus(models.TenantActivityStatusCOLD)...).
-						WithClassName(classPizza).
-						Do(ctx)
+					err := updateTentantWithRetry(client, classPizza, batch[half:].WithStatus(models.TenantActivityStatusCOLD))
 					requireNil(err)
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[half:].WithStatus(models.TenantActivityStatusHOT)...).
-						WithClassName(classPizza).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classPizza, batch[half:].WithStatus(models.TenantActivityStatusHOT))
 					requireNil(err)
 
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[half:].WithStatus(models.TenantActivityStatusCOLD)...).
-						WithClassName(classSoup).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classSoup, batch[half:].WithStatus(models.TenantActivityStatusCOLD))
 					requireNil(err)
-					err = client.Schema().TenantsUpdater().
-						WithTenants(batch[half:].WithStatus(models.TenantActivityStatusHOT)...).
-						WithClassName(classSoup).
-						Do(ctx)
+					err = updateTentantWithRetry(client, classSoup, batch[half:].WithStatus(models.TenantActivityStatusHOT))
 					requireNil(err)
 
 					log.Printf("loop [%d][%d] batch [%d] activated\n", l, i, batchNum)
 				}
 
-				err = client.Schema().TenantsUpdater().
-					WithClassName(classPizza).
-					WithTenants(batch[half:].WithStatus(models.TenantActivityStatusCOLD)...).
-					Do(ctx)
+				err = updateTentantWithRetry(client, classPizza, batch[half:].WithStatus(models.TenantActivityStatusCOLD))
 				requireNil(err)
-				err = client.Schema().TenantsUpdater().
-					WithClassName(classSoup).
-					WithTenants(batch[half:].WithStatus(models.TenantActivityStatusCOLD)...).
-					Do(ctx)
+				err = updateTentantWithRetry(client, classSoup, batch[half:].WithStatus(models.TenantActivityStatusCOLD))
 				requireNil(err)
 			}
 		)
@@ -673,6 +612,29 @@ func test2() {
 	// ==================================================================================
 
 	log.Println("TEST 2 finished. OK")
+}
+
+func updateTentantWithRetry(client *wvt.Client, className string, tenants Tenants) error {
+	const maxRetries = 3
+	var err error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err = client.Schema().TenantsUpdater().
+			WithClassName(className).
+			WithTenants(tenants...).
+			Do(context.Background())
+		if err == nil {
+			return err
+		}
+		fmt.Printf("Attempt %d/%d failed: %v\n", attempt, maxRetries, err)
+
+		if attempt == maxRetries {
+			fmt.Println("Max retries reached. Aborting.")
+			return err
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+	return err
 }
 
 func assertTenantActive(client *wvt.Client, className, tenantName string) {
@@ -723,14 +685,48 @@ func assertActiveTenantObjects(client *wvt.Client, className, tenantName string,
 }
 
 func assertInactiveTenantObjects(client *wvt.Client, className, tenantName string) {
+	const maxRetries = 3
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		err := isInactiveTenantObjects(client, className, tenantName)
+		if err == nil {
+			return
+		}
+		fmt.Printf("Attempt %d/%d failed: %v\n", attempt, maxRetries, err)
+
+		if attempt == maxRetries {
+			fmt.Println("Max retries reached. Aborting.")
+			panic(err)
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func isInactiveTenantObjects(client *wvt.Client, className, tenantName string) error {
 	objects, err := client.Data().ObjectsGetter().
 		WithClassName(className).
 		WithTenant(tenantName).
 		Do(context.Background())
+	if err == nil {
+		return fmt.Errorf("expected error but got nil")
+	}
 
-	requireNotNil(err)
-	clientErr := err.(*fault.WeaviateClientError)
-	requireTrue(422 == clientErr.StatusCode, "422 == clientErr.StatusCode")
-	requireContains(clientErr.Msg, "tenant not active")
-	requireNil(objects)
+	clientErr, ok := err.(*fault.WeaviateClientError)
+	if !ok {
+		return fmt.Errorf("unexpected error type: %v", err)
+	}
+
+	if clientErr.StatusCode != 422 {
+		return fmt.Errorf("expected status code 422 but got %d", clientErr.StatusCode)
+	}
+
+	if !strings.Contains(clientErr.Msg, "tenant not active") {
+		return fmt.Errorf("expected message to contain 'tenant not active' but got: %s", clientErr.Msg)
+	}
+
+	if objects != nil {
+		return fmt.Errorf("expected objects to be nil but got: %v", objects)
+	}
+
+	return nil
 }

--- a/async_repair.sh
+++ b/async_repair.sh
@@ -20,8 +20,9 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 
 echo "Done generating."
 
+export COMPOSE="apps/weaviate/docker-compose-replication_single_voter.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -38,7 +39,7 @@ fi
 
 # ADD objects with one node down, consistency level QUORUM
 echo "Killing node 3"
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f $COMPOSE kill weaviate-node-3
 sleep 10
 if docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name importer_additional -t importer_additional; then
   echo "All objects added with consistency level QUORUM with one node down".
@@ -48,7 +49,7 @@ fi
 
 # Restart dead node, read objects with consistency level ALL
 echo "Restart node 3"
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-3
 wait_weaviate 8082
 # Give some time for async repair to restore the objects in the restarted node
 sleep 5

--- a/backup_and_flush.sh
+++ b/backup_and_flush.sh
@@ -7,8 +7,9 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/backup-and-flush/ && docker build -t backup_and_flush . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/backup_and_restore_crud.sh
+++ b/backup_and_restore_crud.sh
@@ -7,8 +7,9 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/backup_and_restore_crud/ && docker build -t backup_and_restore_crud . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/backup_and_restore_multi_node_crud.sh
+++ b/backup_and_restore_multi_node_crud.sh
@@ -40,13 +40,15 @@ echo "Building all required containers"
 export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
 export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
 
+export COMPOSE="apps/weaviate/docker-compose-backup.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 backup-s3
 
 wait_weaviate_cluster
 
 echo "Creating S3 bucket..."
-docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+docker compose -f $COMPOSE up create-s3-bucket
 
 echo "Run multi-node backup and restore CRUD operations"
 docker run --network host -t backup_and_restore_crud python3 backup_and_restore_crud.py

--- a/backup_and_restore_multi_node_out_of_sync.sh
+++ b/backup_and_restore_multi_node_out_of_sync.sh
@@ -35,13 +35,15 @@ echo "Building all required containers"
 export WEAVIATE_NODE_1_VERSION=$WEAVIATE_VERSION
 export WEAVIATE_NODE_2_VERSION=$WEAVIATE_VERSION
 
+export COMPOSE="apps/weaviate/docker-compose-backup.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-node-2 backup-s3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 backup-s3
 
 wait_weaviate_cluster
 
 echo "Creating S3 bucket..."
-docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+docker compose -f $COMPOSE up create-s3-bucket
 
 echo "Run multi-node backup and restore which affects schema"
 docker run --network host -t backup_and_restore_out_of_sync python3 backup_and_restore_out_of_sync.py

--- a/backup_and_restore_version_compatibility.sh
+++ b/backup_and_restore_version_compatibility.sh
@@ -57,22 +57,24 @@ for pair in "${!version_pairs[@]}"; do
   export WEAVIATE_NODE_1_VERSION=$backup_version
   export WEAVIATE_NODE_2_VERSION=$restore_version
 
+  export COMPOSE="apps/weaviate/docker-compose-backup.yml"
+
   echo "Starting Weaviate cluster..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml up -d weaviate-node-1 weaviate-backup-node backup-s3
+  docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-backup-node backup-s3
 
   wait_weaviate_cluster
 
   echo "Creating S3 bucket..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml up create-s3-bucket
+  docker compose -f $COMPOSE up create-s3-bucket
 
   echo "Run backup (v${backup_version}) and restore (v${restore_version}) version compatibility operations"
   docker run --rm --network host -t backup_and_restore_version_compatibility python3 backup_and_restore_version_compatibility.py
 
   echo "Removing S3 bucket..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml up remove-s3-bucket
+  docker compose -f $COMPOSE up remove-s3-bucket
 
   echo "Cleaning up containers for next test..."
-  docker compose -f apps/weaviate/docker-compose-backup.yml down --remove-orphans
+  docker compose -f $COMPOSE down --remove-orphans
 done
 
 echo "Passed!"

--- a/batch_import_many_classes.sh
+++ b/batch_import_many_classes.sh
@@ -7,8 +7,9 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/batch-import-many-classes/ && docker build -t batch_import_many_classes . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/batch_insert_mismatch.sh
+++ b/batch_insert_mismatch.sh
@@ -7,8 +7,9 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/batch-insert-mismatch/ && docker build -t batch-insert-mismatch . )
 
+export COMPOSE="apps/weaviate/docker-compose-c11y.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-c11y.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/bm25_corruption.sh
+++ b/bm25_corruption.sh
@@ -9,13 +9,15 @@ SIZE=600000
 echo "Building all required containers"
 ( cd apps/bm25-corruption/ && docker build -t importer . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 
 function debug_logs() {
-  docker compose -f apps/weaviate/docker-compose.yml logs --tail 100
+  docker compose -f $COMPOSE logs --tail 100
 }
 trap debug_logs ERR
 

--- a/common.sh
+++ b/common.sh
@@ -4,17 +4,14 @@ set -e
 
 function logs() {
   echo "Showing logs:"
-  compose_files=$(ls apps/weaviate/docker-compose-*.yml)
-  for file in $compose_files; do
-    services=$(docker compose -f "$file" config --services)
-    # Loop through each service
-    for service in $services; do
-      # Check if the service name starts with "weaviate"
-      if [[ $service == weaviate* ]]; then
-        # Fetch and print logs for the matching service
-        docker compose -f "$file" logs "$service"
-      fi
-    done
+  services=$(docker compose -f "$COMPOSE" config --services)
+  # Loop through each service
+  for service in $services; do
+    # Check if the service name starts with "weaviate"
+    if [[ $service == weaviate* ]]; then
+      # Fetch and print logs for the matching service
+      docker compose -f "$COMPOSE" logs "$service"
+    fi
   done
 }
 
@@ -42,11 +39,8 @@ function shutdown() {
     echo "There are $container_count containers."
     docker container rm -f $(docker container ls -aq)
   fi
-    
-  compose_files=$(ls apps/weaviate/docker-compose-*.yml)
-  for file in $compose_files; do
-    docker compose -f "$file" down --remove-orphans
-  done
+
+  docker compose -f "$COMPOSE" down --remove-orphans
   
   rm -rf apps/weaviate/data* || true    
   rm -rf workdir

--- a/compaction_roaringset.sh
+++ b/compaction_roaringset.sh
@@ -7,16 +7,11 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/compaction-roaringset/ && docker build -t compaction-roaringset . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
 echo "Starting Weaviate..."
-PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS=1 docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS=1 docker compose -f $COMPOSE up -d
 
 wait_weaviate
-
-function dump_logs() {
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
-}
-
-trap 'dump_logs' ERR
 
 echo "Run create/delete objects script designed to panic on compacting roaringsets"
 docker run --network host -t compaction-roaringset python3 run.py

--- a/compare_recall_after_restart.sh
+++ b/compare_recall_after_restart.sh
@@ -17,8 +17,10 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" -t reca
 
 echo "Done generating."
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 
@@ -29,8 +31,8 @@ echo "Check Recall"
 docker run --network host -v "$PWD/workdir/:/app/data" -t recall-checker
 
 echo "Restart Weaviate"
-docker compose -f apps/weaviate/docker-compose.yml stop weaviate && \
-  docker compose -f apps/weaviate/docker-compose.yml start weaviate
+docker compose -f $COMPOSE stop weaviate && \
+  docker compose -f $COMPOSE start weaviate
 
 wait_weaviate
 

--- a/compare_rest_graphql_while_crashing.sh
+++ b/compare_rest_graphql_while_crashing.sh
@@ -8,8 +8,9 @@ echo "Building all required containers"
 ( cd apps/compare-rest-graphql/ && docker build -t compare-rest-graphql . )
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/concurrent_inverted_index_read_write.sh
+++ b/concurrent_inverted_index_read_write.sh
@@ -9,8 +9,10 @@ SIZE=100000
 echo "Building all required containers"
 ( cd apps/importer-concurrent-inverted-index/ && docker build -t importer . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/consecutive_create_and_update_operations.sh
+++ b/consecutive_create_and_update_operations.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/consecutive_create_and_update_operations/ && docker build -t consecutive_create_and_update_operations . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/counting_while_compacting.sh
+++ b/counting_while_compacting.sh
@@ -7,13 +7,15 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/counting-while-compacting/ && docker build -t counting-while-compacting . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 
 function dump_logs() {
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f $COMPOSE logs
   docker ps -a
 }
 

--- a/debug-reindexing.sh
+++ b/debug-reindexing.sh
@@ -17,7 +17,8 @@ function wait_weaviate() {
 }
 
 function shutdown() {
-  echo "Cleaning up ressources..."
+  echo "Cleaning up resources..."
+  popd || true
   docker compose -f apps/debug-reindexing-endpoint/docker-compose.yml down --remove-orphans
   rm -rf apps/weaviate/data* || true
 }
@@ -33,7 +34,8 @@ wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
 
-cd ./apps/debug-reindexing-endpoint/ && go test  -timeout 3600s -v . # 1 hour timeout 
+pushd ./apps/debug-reindexing-endpoint
+go test -timeout 3600s -v  # 1 hour timeout
 
 echo "Passed!"
 shutdown

--- a/delete_and_recreate_class.sh
+++ b/delete_and_recreate_class.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/delete_and_recreate && docker build -t delete_and_recreate . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/deletes_with_node_out_of_sync.sh
+++ b/deletes_with_node_out_of_sync.sh
@@ -24,8 +24,10 @@ docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name 
 
 echo "Done generating."
 
+export COMPOSE="apps/weaviate/docker-compose-replication_single_voter.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -44,14 +46,14 @@ fi
 docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name regenerator -t regenerator
 
 echo "Killing node 3"
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml kill weaviate-node-3
+docker compose -f $COMPOSE kill weaviate-node-3
 sleep 10
 # Import tenant2 objects with one node down, consistency level QUORUM
 docker run --network host -v "$PWD/workdir/data.json:/workdir/data.json" --name reimporter -t reimporter
 
 # Restart dead node, read objects from Node 3 with consistency level ONE
 echo "Restart node 3"
-docker compose -f apps/weaviate/docker-compose-replication_single_voter.yml up -d weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-3
 wait_weaviate 8082
 
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name check_objects_in_nodes -t check_objects_in_nodes; then

--- a/filter_memory_leak.sh
+++ b/filter_memory_leak.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/filter-memory-leak// && docker build -t leaker . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose-with-memlimit.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/geo_crash.sh
+++ b/geo_crash.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/geo-crash/ && docker build -t geo_crash . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/goroutine_leak_on_class_delete.sh
+++ b/goroutine_leak_on_class_delete.sh
@@ -7,11 +7,13 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/goroutine-leak-on-class-delete/ && docker build -t goroutine-test-script . )
 
+export COMPOSE="apps/weaviate/docker-compose-cpu-constrained.yml"
+
 # We are reusing the replication docker compose for this, but there is nothing
 # special about the infra, it's essentially just a 3-node cluster which is
 # perfect for this test
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-cpu-constrained.yml up -d
+docker compose -f $COMPOSE up -d
 wait_weaviate 8080
 
 echo "Run test script"

--- a/import_while_crashing.sh
+++ b/import_while_crashing.sh
@@ -10,8 +10,10 @@ echo "Building all required containers"
 ( cd apps/importer/ && docker build -t importer . )
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/import_while_crashing_no_vector.sh
+++ b/import_while_crashing_no_vector.sh
@@ -10,8 +10,10 @@ echo "Building all required containers"
 ( cd apps/importer-no-vector-index/ && docker build -t importer-no-vector . )
 ( cd apps/chaotic-killer/ && docker build -t killer . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/multi_node_ref_imports.sh
+++ b/multi_node_ref_imports.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/multi-node-references && docker build -t ref-importer . )
 
+export COMPOSE="apps/weaviate/docker-compose-replication.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082
@@ -25,9 +27,9 @@ if ! docker run \
 fi
 
 echo "Check for error logs"
-errors="$(docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error | wc -l | tr -d '[:space:]')"
+errors="$(docker compose -f $COMPOSE logs 2>&1 | grep memberlist | grep error | wc -l | tr -d '[:space:]')"
 if (( $warnings > 0 )); then
-  docker compose -f apps/weaviate/docker-compose-replication.yml logs 2>&1 | grep memberlist | grep error
+  docker compose -f $COMPOSE logs 2>&1 | grep memberlist | grep error
   echo "too many errors ($errors)"
   exit 1
 fi

--- a/multi_tenancy_activate_deactivate.sh
+++ b/multi_tenancy_activate_deactivate.sh
@@ -6,9 +6,10 @@ source common.sh
 
 git submodule update --init --remote --recursive
 
+export COMPOSE="apps/weaviate/docker-compose-replication.yml"
 
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082

--- a/multi_tenancy_activate_deactivate_v1_24.sh
+++ b/multi_tenancy_activate_deactivate_v1_24.sh
@@ -6,9 +6,10 @@ source common.sh
 
 git submodule update --init --remote --recursive
 
+export COMPOSE="apps/weaviate/docker-compose-replication.yml"
 
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082

--- a/multi_tenancy_concurrent_importing.sh
+++ b/multi_tenancy_concurrent_importing.sh
@@ -6,9 +6,10 @@ source common.sh
 
 git submodule update --init --remote --recursive
 
+export COMPOSE="apps/weaviate/docker-compose-replication.yml"
 
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082

--- a/replication_importing_while_crashing.sh
+++ b/replication_importing_while_crashing.sh
@@ -10,9 +10,10 @@ echo "Building all required containers"
 ( cd apps/replicated-import/ && docker build -t importer . )
 ( cd apps/chaotic-cluster-killer/ && docker build -t killer . )
 
-echo "Starting Weaviate..."
+export COMPOSE="apps/weaviate/docker-compose-replication.yml"
 
-docker compose -f apps/weaviate/docker-compose-replication.yml up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
+echo "Starting Weaviate..."
+docker compose -f $COMPOSE up -d weaviate-node-1 weaviate-node-2 weaviate-node-3
 wait_weaviate 8080
 wait_weaviate 8081
 wait_weaviate 8082

--- a/replication_importing_with_backup.sh
+++ b/replication_importing_with_backup.sh
@@ -8,8 +8,10 @@ function compose_exit_code() {
   echo $(docker inspect $1 --format='{{.State.ExitCode}}')
 }
 
+export COMPOSE="apps/replicated_import_with_backup/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/replicated_import_with_backup/docker-compose.yml up -d \
+docker compose -f $COMPOSE up -d \
   weaviate-node-1 \
   weaviate-node-2 \
   weaviate-node-3 \
@@ -20,11 +22,11 @@ wait_weaviate 8081
 wait_weaviate 8082
 
 echo "Creating S3 bucket..."
-docker compose -f apps/replicated_import_with_backup/docker-compose.yml up \
+docker compose -f $COMPOSE up \
   create-s3-bucket
 
 echo "Creating schema..."
-docker compose -f apps/replicated_import_with_backup/docker-compose.yml up \
+docker compose -f $COMPOSE up \
   importer-schema-node-1
 
 if [ $(compose_exit_code importer-schema-node-1) -ne 0 ]; then
@@ -33,7 +35,7 @@ if [ $(compose_exit_code importer-schema-node-1) -ne 0 ]; then
 fi
 
 echo "Batch import to 2 nodes + parallel backup..."
-docker compose -f apps/replicated_import_with_backup/docker-compose.yml up \
+docker compose -f $COMPOSE up \
   importer-data-node-1 \
   importer-data-node-2 \
   backup-loop-node-1 \

--- a/rest_patch_stops_working_after_restart.sh
+++ b/rest_patch_stops_working_after_restart.sh
@@ -7,8 +7,10 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/rest-patch-stops-working-after-restart/ && docker build -t rest-patch-stops-working-after-restart . )
 
+export COMPOSE="apps/weaviate/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 
@@ -16,8 +18,8 @@ echo "Run consecutive update operations"
 docker run --network host -t rest-patch-stops-working-after-restart python3 rest-patch-stops-working-after-restart.py
 
 echo "Restart Weaviate..."
-docker compose -f apps/weaviate/docker-compose.yml stop
-docker compose -f apps/weaviate/docker-compose.yml up -d
+docker compose -f $COMPOSE stop
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 

--- a/segfault_batch_ref.sh
+++ b/segfault_batch_ref.sh
@@ -7,12 +7,14 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/segfault-on-batch-ref/ && docker build -t segfault_batch_ref . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 wait_weaviate
 
 function dump_logs() {
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f $COMPOSE logs
 }
 
 trap 'dump_logs' ERR

--- a/segfault_filtered_vector_search.sh
+++ b/segfault_filtered_vector_search.sh
@@ -7,13 +7,15 @@ source common.sh
 echo "Building all required containers"
 ( cd apps/segfault-on-filtered-vector-search/ && docker build -t segfault_filtered_vector_search . )
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
+
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 wait_weaviate
 
 function dump_logs() {
-  docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml logs
+  docker compose -f $COMPOSE logs
 }
 
 trap 'dump_logs' ERR

--- a/update_stability.sh
+++ b/update_stability.sh
@@ -17,9 +17,10 @@ set -e
 
 dataset=${DATASET:-"dbpedia-100k-openai-ada002-angular"}
 
+export COMPOSE="apps/weaviate-no-restart-on-crash/docker-compose.yml"
 
 echo "Starting Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml up -d
+docker compose -f $COMPOSE up -d
 
 
 echo "Run benchmark script"
@@ -48,6 +49,6 @@ docker run --network host -t -v "$PWD/results:/app/results" -v "$PWD/datasets:/a
   semitechnologies/weaviate-benchmarker:v2.0.0 /app/scripts/shell/update_stability.sh
 
 echo "Stopping Weaviate..."
-docker compose -f apps/weaviate-no-restart-on-crash/docker-compose.yml down
+docker compose -f $COMPOSE down
 
 echo "Passed!"

--- a/upgrade_single_node_journey.sh
+++ b/upgrade_single_node_journey.sh
@@ -4,10 +4,12 @@ set -e
 
 source common.sh
 
+export COMPOSE="apps/weaviate/docker-compose-single-voter-without-node-name.yml"
+
 function restart() {
   echo "Restarting node ..."
-  docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml kill weaviate-node-1
-  docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml up -d --force-recreate  weaviate-node-1
+  docker compose -f $COMPOSE kill weaviate-node-1
+  docker compose -f $COMPOSE up -d --force-recreate  weaviate-node-1
   wait_weaviate 8080
 }
 
@@ -18,7 +20,7 @@ function validateObjects() {
   if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_healthy -t cluster_healthy; then
     echo "All objects read with consistency level ONE".
   else
-    docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml logs weaviate-node-1
+    docker compose -f $COMPOSE logs weaviate-node-1
     exit 1
   fi
 }
@@ -39,7 +41,7 @@ echo "Done generating."
 
 echo "Starting Weaviate 1.25..."
 export WEAVIATE_NODE_VERSION=1.25.0
-docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml up -d weaviate-node-1
+docker compose -f $COMPOSE up -d weaviate-node-1
 wait_weaviate 8080
 
 # POST objects with consistency level ONE
@@ -50,7 +52,7 @@ validateObjects
 
 echo "Upgrade Weaviate..."
 export WEAVIATE_NODE_VERSION=$WEAVIATE_VERSION
-docker compose -f apps/weaviate/docker-compose-single-voter-without-node-name.yml up -d --force-recreate  weaviate-node-1
+docker compose -f $COMPOSE up -d --force-recreate  weaviate-node-1
 wait_weaviate 8080
 
 


### PR DESCRIPTION
* Improve handling of COMPOSE files for shutting down and logging As currently it was displaying logs only for weaviate-node-1 and 2.
* Reduce iterations for go leak tests, as they go over 1hour.
* Fix issue with golang version in debug-reindexing as fixing the module naming.
* Add retries in several function during multi-tenancy-activate-deactivate in give time to Weaviate to propagate changes 
* Importer: Add retries if the result code is not 200
* replication-tunable-consistency: Increase runner size