### PR TITLE
Adding a timeout mechanism in case compaction doesn't finish.

### DIFF
--- a/compaction_optimization.sh
+++ b/compaction_optimization.sh
@@ -92,6 +92,14 @@ while true; do
     break
   fi
   
+  # Check for timeout
+  current_time=$(date +%s)
+  elapsed_time=$((current_time - start_time))
+  if [ $elapsed_time -ge $timeout ]; then
+    echo "Timeout reached. Compaction did not finish in the expected time."
+    break
+  fi
+  
   prev_count=$levels_count
   
   echo "Compaction ongoing. Waiting..."


### PR DESCRIPTION
The block that waits for compaction to finish was missing a timeout mechanism. All needed items, the timeout and starting_time were present but the condition to exit the loop was missing. Adding it