### PR TITLE
Pin the weaviate-python-client version for tests using v3.

### DIFF
--- a/apps/backup-and-flush/requirements.txt
+++ b/apps/backup-and-flush/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3
 

--- a/apps/backup_and_restore_crud/requirements.txt
+++ b/apps/backup_and_restore_crud/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3
 

--- a/apps/backup_and_restore_out_of_sync/requirements.txt
+++ b/apps/backup_and_restore_out_of_sync/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.9.7,<4.5.0
 numpy==1.22.2
 loguru==0.5.3
 

--- a/apps/backup_and_restore_version_compatibility/requirements.txt
+++ b/apps/backup_and_restore_version_compatibility/requirements.txt
@@ -1,3 +1,3 @@
-weaviate-client==3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3

--- a/apps/compaction-roaringset/requirements.txt
+++ b/apps/compaction-roaringset/requirements.txt
@@ -1,2 +1,2 @@
-weaviate-client>=3.11.0
+weaviate-client>=3.26.7,<4.0.0
 loguru==0.6.0

--- a/apps/consecutive_create_and_update_operations/requirements.txt
+++ b/apps/consecutive_create_and_update_operations/requirements.txt
@@ -1,1 +1,1 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0

--- a/apps/delete_and_recreate/requirements.txt
+++ b/apps/delete_and_recreate/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3
 

--- a/apps/filter-memory-leak/requirements.txt
+++ b/apps/filter-memory-leak/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.11.0
+weaviate-client>=3.26.7,<4.0.0
 loguru==0.5.3
 numpy==1.22.2
 

--- a/apps/geo-crash/requirements.txt
+++ b/apps/geo-crash/requirements.txt
@@ -1,3 +1,3 @@
-weaviate-client>=3.11.0
+weaviate-client>=3.26.7,<4.0.0
 loguru==0.5.3
 

--- a/apps/multi-node-references/requirements.txt
+++ b/apps/multi-node-references/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.22.2
 loguru==0.5.3
-weaviate-client>=3.19.0
+weaviate-client>=3.26.7,<4.0.0
 backoff==2.2.1

--- a/apps/recall/requirements.txt
+++ b/apps/recall/requirements.txt
@@ -1,3 +1,3 @@
 torch==1.13+cpu
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 nltk==3.5

--- a/apps/replicated-import/requirements.txt
+++ b/apps/replicated-import/requirements.txt
@@ -1,4 +1,4 @@
 numpy==1.22.2
 loguru==0.5.3
-weaviate-client>=3.11.0
+weaviate-client>=3.26.7,<4.0.0
 

--- a/apps/replicated_import_with_backup/requirements.txt
+++ b/apps/replicated_import_with_backup/requirements.txt
@@ -1,2 +1,2 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 loguru==0.5.3

--- a/apps/rest-patch-stops-working-after-restart/requirements.txt
+++ b/apps/rest-patch-stops-working-after-restart/requirements.txt
@@ -1,2 +1,2 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 loguru==0.6.0

--- a/apps/segfault-on-batch-ref/requirements.txt
+++ b/apps/segfault-on-batch-ref/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3
 

--- a/apps/segfault-on-filtered-vector-search/requirements.txt
+++ b/apps/segfault-on-filtered-vector-search/requirements.txt
@@ -1,4 +1,4 @@
-weaviate-client>=3.9.0
+weaviate-client>=3.26.7,<4.0.0
 numpy==1.22.2
 loguru==0.5.3
 


### PR DESCRIPTION
The Python v3 client has been deprecated in recent versions and we get now the following error if still using it with the latest versions Upgrade your code to use Python client v4  connections and methods.
    - For Python Client v4 usage, see: https://weaviate.io/developers/weaviate/client-libraries/python
    - For code migration, see: https://weaviate.io/developers/weaviate/client-libraries/python/v3_v4_migration

If you have to use v3 code, install the v3 client and pin the v3 dependency in your requirements file:
  client = weaviate.Client(host, timeout_config=int(30))