### PR TITLE
Increase the delay to wait for async replication.

### DIFF
--- a/async_repair.sh
+++ b/async_repair.sh
@@ -52,7 +52,7 @@ echo "Restart node 3"
 docker compose -f $COMPOSE up -d weaviate-node-3
 wait_weaviate 8082
 # Give some time for async repair to restore the objects in the restarted node
-sleep 5
+sleep 30
 if docker run --network host -v "$PWD/workdir/:/workdir/data" --name cluster_async_repair -t cluster_async_repair; then
   echo "All objects read with consistency level ALL after weaviate-node-3 restarted".
 else


### PR DESCRIPTION
In a recent change, the async replication time at which the repairing occurs has been modified and added a new environemtn variable which allows its configuration. The default value is 30 seconds, therefore we need to wait a little longer.