### PR TITLE
Remove Scarf's proxy reference.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,6 +36,11 @@ jobs:
     outputs:
       real_version: ${{ steps.weaviate-version-from-image.outputs.weaviate_version }}
     steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
       - name: Retrieve the weaviate version from the image
         uses: weaviate/github-common-actions/.github/actions/weaviate-version-in-image@main
         id: weaviate-version-from-image
@@ -104,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -130,7 +135,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -165,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -201,7 +206,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -238,7 +243,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -274,7 +279,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -311,7 +316,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -344,7 +349,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -377,7 +382,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -412,7 +417,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -439,7 +444,7 @@ jobs:
         with:
           go-version: '1.20'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -466,7 +471,7 @@ jobs:
         with:
           go-version: '1.20'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -487,7 +492,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -510,7 +515,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -531,7 +536,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -552,7 +557,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -573,7 +578,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -594,7 +599,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -615,7 +620,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -636,7 +641,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -657,7 +662,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -678,7 +683,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -699,7 +704,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -720,7 +725,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -741,7 +746,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -762,7 +767,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -783,7 +788,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -804,7 +809,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -825,7 +830,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -842,7 +847,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -863,7 +868,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -884,7 +889,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -905,7 +910,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -926,7 +931,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -948,7 +953,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -970,7 +975,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -991,7 +996,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1012,7 +1017,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1034,7 +1039,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1056,7 +1061,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1073,7 +1078,7 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v3
   #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v2
+  #       uses: docker/login-action@v3
   #       with:
   #         username: ${{secrets.DOCKER_USERNAME}}
   #         password: ${{secrets.DOCKER_PASSWORD}}
@@ -1096,7 +1101,7 @@ jobs:
         with:
           go-version: '1.20'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1115,7 +1120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1220,7 +1225,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1276,7 +1281,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1305,7 +1310,7 @@ jobs:
       #     polarsignals_cloud_token: ${{ secrets.POLARSIGNALS_TOKEN }}
       #     labels: 'job=${{ github.job }};gh_run_id=${{ github.run_id }}'
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1322,7 +1327,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1344,7 +1349,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
@@ -1366,7 +1371,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}

--- a/apps/upgrade-journey-object-nested-properties/docker-compose-single.yml
+++ b/apps/upgrade-journey-object-nested-properties/docker-compose-single.yml
@@ -8,7 +8,7 @@ services:
     - '8080'
     - --scheme
     - http
-    image: cr.weaviate.io/semitechnologies/weaviate:${DOCKER_COMPOSE_VERSION}
+    image: semitechnologies/weaviate:${DOCKER_COMPOSE_VERSION}
     ports:
     - 8080:8080
     - 50051:50051

--- a/upgrade_journey_object_nested_properties.sh
+++ b/upgrade_journey_object_nested_properties.sh
@@ -3,12 +3,12 @@
 set -eou pipefail
 
 if [[ -z "${WEAVIATE_VERSION}" ]]; then
-  ech "WEAVIATE_VERSION is undefined"
+  echo "WEAVIATE_VERSION is undefined"
   exit 1
 fi
 
 if [[ -z "${PERSISTENCE_LSM_ACCESS_STRATEGY}" ]]; then
-  ech "PERSISTENCE_LSM_ACCESS_STRATEGY is undefined"
+  echo "PERSISTENCE_LSM_ACCESS_STRATEGY is undefined"
   exit 1
 fi
 


### PR DESCRIPTION
The upgrade journey nested properties job has been seen failing during [chaos-pieline](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/13742671744/job/38433745323) execution:
```
 Upgrade journey test: single
Start Weaviate v1.25.24
 weaviate Pulling 
 weaviate Error toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
Error: Process completed with exit code 18.
```
Being the reason that the docker-compose file was pointing at Scarf's proxy registry. This PR removes that reference and uses directly Dockerhub's registry.

Also, as part of this PR, we are updating the docker/login-action to the version v3.