### PR TITLE
Muvera: fix version check to run Muvera test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -624,7 +624,7 @@ jobs:
   ann-benchmarks-multivector-muvera-gcp:
     name: "[bench GCP] MULTIVECTOR MUVERA"
     needs: [newer-or-equal-than-1_31]
-    if: ${{ (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    if: ${{ (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:


### PR DESCRIPTION
The if condition to run the test was not correct and the test was being executed for all Weaviate versions.

Fix it to be executed only in Weaviate >= 1.31