### PR TITLE
Add RQ test cases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -184,7 +184,7 @@ jobs:
         uses: fabriziocacicia/semver-compare-action@v0.1.0
         with:
           first: ${{ needs.real-version-in-tag.outputs.real_version }}
-          second: "1.32.0"
+          second: "1.32.0-dev"  # TODO: change to 1.32.0 when the version is released
           operator: ">="
   filter-memory-leak:
     name: Filter (cache) memory leak when querying while importing

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -172,6 +172,20 @@ jobs:
           first: ${{ needs.real-version-in-tag.outputs.real_version }}
           second: "1.31.0"
           operator: ">="
+  newer-or-equal-than-1_32:
+    name: "Check if the version is newer than 1.32"
+    needs: real-version-in-tag
+    runs-on: ubuntu-latest
+    outputs:
+      check: ${{ steps.semver_compare.outputs.result }}
+    steps:
+      - name: Semver Compare
+        id: semver_compare
+        uses: fabriziocacicia/semver-compare-action@v0.1.0
+        with:
+          first: ${{ needs.real-version-in-tag.outputs.real_version }}
+          second: "1.32.0"
+          operator: ">="
   filter-memory-leak:
     name: Filter (cache) memory leak when querying while importing
     if: ${{ github.event.inputs.test_to_run == 'filter-memory-leak' || github.event.inputs.test_to_run == '' }}
@@ -425,6 +439,48 @@ jobs:
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
 
+  ann-benchmarks-rq-glove-aws:
+    needs: [newer-or-equal-than-1_32]
+    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-glove-aws' || github.event.inputs.test_to_run == '') }}
+    name: "[bench AWS] Glove100 rq=true"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY}}
+      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      DATASET: glove-100-angular
+      DISTANCE: cosine
+      REQUIRED_RECALL: 0.89
+      QUANTIZATION: rq
+      PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        if: always()
+        run: ./ann_benchmark_quantization_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+
+
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
     if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-sift-gcp' || github.event.inputs.test_to_run == '' }}
@@ -473,6 +529,7 @@ jobs:
       REQUIRED_RECALL: 0.992
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
       BOOT_DISK_SIZE: 20GB
+      QUANTIZATION: pq
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -499,6 +556,49 @@ jobs:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
+
+  ann-benchmarks-rq-sift-gcp:
+    needs: [newer-or-equal-than-1_32]
+    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-rq-sift-gcp' || github.event.inputs.test_to_run == '') }}
+    name: "[bench GCP] SIFT1M rq=true"
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DATASET: sift-128-euclidean
+      DISTANCE: l2-squared
+      REQUIRED_RECALL: 0.992
+      PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
+      BOOT_DISK_SIZE: 20GB
+      QUANTIZATION: rq
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Run chaos test
+        if: always()
+        run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
+
+
+
   ann-benchmarks-multivector-gcp:
     name: "[bench GCP] MULTIVECTOR3M"
     needs: [newer-or-equal-than-1_29]
@@ -618,10 +718,10 @@ jobs:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
-  ann-benchmarks-multivector-bq-gcp:
-    name: "[bench GCP] MULTIVECTOR3M bq=true"
-    needs: [newer-or-equal-than-1_30]
-    if: ${{ (needs.newer-or-equal-than-1_30.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-bq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+  ann-benchmarks-multivector-rq-gcp:
+    name: "[bench GCP] MULTIVECTOR3M rq=true"
+    needs: [newer-or-equal-than-1_32]
+    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-rq-gcp' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -631,7 +731,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
       BOOT_DISK_SIZE: 40GB
       MULTIVECTOR_DATASET: true
-      QUANTIZATION: bq
+      QUANTIZATION: rq
     steps:
       - uses: actions/checkout@v3
       - name: Login to Docker Hub
@@ -658,6 +758,7 @@ jobs:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
+
   ann-benchmarks-multivector-muvera-gcp:
     name: "[bench GCP] MULTIVECTOR MUVERA"
     needs: [newer-or-equal-than-1_31]
@@ -704,12 +805,59 @@ jobs:
       - name: Cleanup GCP resources
         if: always()
         run: ./cleanup_gcp_resources.sh
+
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
-          glob: '*.json'          
+          glob: '*.json'
+
+
+  ann-benchmarks-multivector-muvera-gcp-rq:
+    name: "[bench GCP] MULTIVECTOR MUVERA and RQ"
+    needs: [newer-or-equal-than-1_32]
+    if: ${{ (needs.newer-or-equal-than-1_32.outputs.check == 'true') && (github.event.inputs.test_to_run == 'ann-benchmarks-multivector-muvera-gcp-rq' || github.event.inputs.test_to_run == '' || github.event.inputs.test_to_run == 'ann-benchmarks-multivector-all') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      DATASET: lotte-recreation-reduced-vl-50000
+      DISTANCE: dot
+      REQUIRED_RECALL: 0.80
+      PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
+      BOOT_DISK_SIZE: 20GB
+      MULTIVECTOR_DATASET: true
+      MULTIVECTOR_IMPLEMENTATION: muvera
+    steps:
+      - uses: actions/checkout@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+
+      - name: Run chaos test with RQ
+        if: always()
+        env:
+          QUANTIZATION: rq
+        run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
+
+      - id: 'upload-files'
+        uses: 'google-github-actions/upload-cloud-storage@v1'
+        with:
+          path: 'results'
+          destination: 'ann-pipelines/github-action-runs'
+          glob: '*.json'
 
   batch-import-many-classes:
     name: One class receives long and expensive batches, user tries to create and delete 100s of classes in parallel

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2259,7 +2259,7 @@ jobs:
 
   hnsw-snapshotting-while-crash:
     needs: [newer-or-equal-than-1_31]
-    if: ${{ (needs.newer-or-equal-than-newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'hnsw-snapshotting-while-crash' || github.event.inputs.test_to_run == '' ) }}
+    if: ${{ (needs.newer-or-equal-than-1_31.outputs.check == 'true') && (github.event.inputs.test_to_run == 'hnsw-snapshotting-while-crash' || github.event.inputs.test_to_run == '' ) }}
     name: Check that HNSW snapshotting works while crashes happen
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/apps/ann-benchmarks/analyze.py
+++ b/apps/ann-benchmarks/analyze.py
@@ -28,6 +28,18 @@ class TestResults(unittest.TestCase):
 
     def test_recall_before_after(self):
         allowed_delta = 0.02
+
+        pd.set_option("display.max_rows", None)
+        pd.set_option("display.max_columns", None)
+        pd.set_option("display.max_colwidth", None)  # For full cell content (especially strings)
+        pd.set_option("display.expand_frame_repr", False)  # Avoid line wrapping for wide DataFrames
+
+        print(self.df.loc[self.df["after_restart"] == "false", "recall"].describe(include="all"))
+        print(self.df.loc[self.df["after_restart"] == "true", "recall"].describe(include="all"))
+
+        print(self.df.loc[self.df["after_restart"] == "false", "recall"])
+        print(self.df.loc[self.df["after_restart"] == "true", "recall"])
+
         mean_recall_before = self.df.loc[self.df["after_restart"] == "false", "recall"].mean()
         mean_recall_after = self.df.loc[self.df["after_restart"] == "true", "recall"].mean()
 

--- a/apps/ann-benchmarks/analyze.py
+++ b/apps/ann-benchmarks/analyze.py
@@ -29,17 +29,6 @@ class TestResults(unittest.TestCase):
     def test_recall_before_after(self):
         allowed_delta = 0.02
 
-        pd.set_option("display.max_rows", None)
-        pd.set_option("display.max_columns", None)
-        pd.set_option("display.max_colwidth", None)  # For full cell content (especially strings)
-        pd.set_option("display.expand_frame_repr", False)  # Avoid line wrapping for wide DataFrames
-
-        print(self.df.loc[self.df["after_restart"] == "false", "recall"].describe(include="all"))
-        print(self.df.loc[self.df["after_restart"] == "true", "recall"].describe(include="all"))
-
-        print(self.df.loc[self.df["after_restart"] == "false", "recall"])
-        print(self.df.loc[self.df["after_restart"] == "true", "recall"])
-
         mean_recall_before = self.df.loc[self.df["after_restart"] == "false", "recall"].mean()
         mean_recall_after = self.df.loc[self.df["after_restart"] == "true", "recall"].mean()
 

--- a/apps/ann-benchmarks/requirements.txt
+++ b/apps/ann-benchmarks/requirements.txt
@@ -1,6 +1,6 @@
-weaviate-client@git+https://github.com/weaviate/weaviate-python-client.git@dev/1.31
+weaviate-client@git+https://github.com/weaviate/weaviate-python-client.git@dev/1.32
 loguru==0.5.3
 seaborn==0.12.2
 h5py==3.13.0
 pandas==2.2.3
-torch==2.6.0
+torch==2.6


### PR DESCRIPTION
This commit introduces Rotational Quantization (RQ) testing support across the ANN benchmarks suite.

# New Test Jobs Added
- ann-benchmarks-rq-glove-aws - AWS Glove100 RQ benchmark testing
- ann-benchmarks-rq-sift-gcp - GCP SIFT1M RQ benchmark testing

# Updated Test Jobs
- Renamed ann-benchmarks-multivector-bq-gcp → ann-benchmarks-multivector-rq-gcp
- Added RQ test step to MUVERA dataset benchmarks

# Implementation Changes
- weaviate_import.py
- Implemented RQ-specific vector index configuration for both single and multivector scenarios
requirements.txt
- Updated weaviate-client to specific commit hash to use temporarily RQ client
