### PR TITLE
Clean ANN resources in CI

### DIFF
--- a/.github/workflows/matrix.yaml
+++ b/.github/workflows/matrix.yaml
@@ -51,6 +51,29 @@ jobs:
       DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       GCP_SERVICE_ACCOUNT_BENCHMARKS: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
       POLARSIGNALS_TOKEN: ${{secrets.POLARSIGNALS_TOKEN}}
+  cleanup-cancelled-instances:
+    needs: [run-with-sync-indexing]
+    if: always() && (cancelled() || failure())
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: 'gcs_auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: ${{secrets.GCP_SERVICE_ACCOUNT_BENCHMARKS}}
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{secrets.AWS_ACCESS_KEY}}
+          aws-secret-access-key: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+          aws-region: eu-central-1
+      - name: Cleanup cancelled GCP instances
+        run: ./cleanup_cancelled_gcp_instances.sh
+      - name: Cleanup cancelled AWS resources
+        run: ./cleanup_cancelled_aws_resources.sh
   send-slack-message-on-failure:
     needs: [weaviate-version-information, run-with-sync-indexing]
     if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -219,6 +219,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -254,6 +257,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -290,6 +296,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -327,6 +336,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -363,6 +375,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -400,12 +415,16 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_aws.sh
+      - name: Cleanup AWS resources
+        if: always()
+        run: ./cleanup_aws_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
           path: 'results'
           destination: 'ann-pipelines/github-action-runs'
           glob: '*.json'
+
   ann-benchmarks-sift-gcp:
     name: "[bench GCP] SIFT1M pq=false"
     if: ${{ github.event.inputs.test_to_run == 'ann-benchmarks-sift-gcp' || github.event.inputs.test_to_run == '' }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -453,6 +453,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -487,6 +490,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -523,6 +529,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -560,6 +569,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -597,6 +609,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -634,6 +649,9 @@ jobs:
       - name: Run chaos test
         if: always()
         run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:
@@ -683,6 +701,9 @@ jobs:
         env:
           QUANTIZATION: sq
         run: ./ann_benchmark_quantization_gcp.sh
+      - name: Cleanup GCP resources
+        if: always()
+        run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -454,7 +454,7 @@ jobs:
         if: always()
         run: ./ann_benchmark_gcp.sh
       - name: Cleanup GCP resources
-        if: always()
+        if: always() || cancelled()
         run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -454,7 +454,7 @@ jobs:
         if: always()
         run: ./ann_benchmark_gcp.sh
       - name: Cleanup GCP resources
-        if: always() || cancelled()
+        if: ${{ always() || cancelled() }}
         run: ./cleanup_gcp_resources.sh
       - id: 'upload-files'
         uses: 'google-github-actions/upload-cloud-storage@v1'

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -15,7 +15,7 @@ region="eu-central-1"
 github_run_id=${GITHUB_RUN_ID:-"local"}
 random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
 run_id="${github_run_id}-${random_suffix}"
-key_id="benchmark-${run_id}"
+key_id="key-$run_id"
 
 # Create cleanup info directory and save region info
 mkdir -p .cleanup_info
@@ -39,7 +39,8 @@ chmod 600 "${key_id}.pem"
 # Save key_id for cleanup
 echo "$key_id" > .cleanup_info/key_id
 
-instance_id=$(aws ec2 run-instances \ --image-id $ami \ --count 1 \ --instance-type $MACHINE_TYPE \ --key-name $key_id \ --security-group-ids $group_id \ --region $region \ --associate-public-ip-address \ --ebs-optimized \ --block-device-mappings "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" \ --instance-initiated-shutdown-behavior terminate \ --user-data '#!/bin/bash shutdown -h +240' \ | jq -r '.Instances[0].InstanceId')
+instance_id=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $MACHINE_TYPE --key-name $key_id --security-group-ids $group_id  --region $region --associate-public-ip-address --cli-read-timeout 600   --ebs-optimized --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" | jq -r '.Instances[0].InstanceId' )
+
 echo "instance ready: $instance_id"
 # Save instance_id for cleanup
 echo "$instance_id" > .cleanup_info/instance_id

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -11,8 +11,10 @@ distance=${DISTANCE:-"l2-squared"}
 
 region="eu-central-1"
 
-# to make sure all aws resources are unique
-run_id=$(uuidgen | tr [:upper:] [:lower:])
+# Generate deterministic run_id using GITHUB_RUN_ID + random string
+github_run_id=${GITHUB_RUN_ID:-"local"}
+random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
+run_id="${github_run_id}-${random_suffix}"
 key_id="key-$run_id"
 
 # Create cleanup info directory and save region info

--- a/ann_benchmark_aws.sh
+++ b/ann_benchmark_aws.sh
@@ -15,7 +15,7 @@ region="eu-central-1"
 github_run_id=${GITHUB_RUN_ID:-"local"}
 random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
 run_id="${github_run_id}-${random_suffix}"
-key_id="key-$run_id"
+key_id="benchmark-${run_id}"
 
 # Create cleanup info directory and save region info
 mkdir -p .cleanup_info
@@ -39,8 +39,7 @@ chmod 600 "${key_id}.pem"
 # Save key_id for cleanup
 echo "$key_id" > .cleanup_info/key_id
 
-instance_id=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $MACHINE_TYPE --key-name $key_id --security-group-ids $group_id  --region $region --associate-public-ip-address --cli-read-timeout 600   --ebs-optimized --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" | jq -r '.Instances[0].InstanceId' )
-
+instance_id=$(aws ec2 run-instances \ --image-id $ami \ --count 1 \ --instance-type $MACHINE_TYPE \ --key-name $key_id \ --security-group-ids $group_id \ --region $region \ --associate-public-ip-address \ --ebs-optimized \ --block-device-mappings "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" \ --instance-initiated-shutdown-behavior terminate \ --user-data '#!/bin/bash shutdown -h +240' \ | jq -r '.Instances[0].InstanceId')
 echo "instance ready: $instance_id"
 # Save instance_id for cleanup
 echo "$instance_id" > .cleanup_info/instance_id

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -24,7 +24,9 @@ gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
   --boot-disk-size=$BOOT_DISK_SIZE \
-  --max-run-duration=4h
+  --max-run-duration=4h \
+  --instance-termination-action=DELETE
+
 
 function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -23,7 +23,8 @@ echo "$instance" > .cleanup_info/instance
 gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
-  --boot-disk-size=$BOOT_DISK_SIZE
+  --boot-disk-size=$BOOT_DISK_SIZE \
+  --max-run-duration=4h
 
 function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -12,13 +12,19 @@ MULTIVECTOR_IMPLEMENTATION=${MULTIVECTOR_IMPLEMENTATION:-"regular"}
 
 instance="benchmark-$(uuidgen | tr [:upper:] [:lower:])"
 
+# Create cleanup info directory and save cleanup information
+mkdir -p .cleanup_info
+echo "$ZONE" > .cleanup_info/zone
+echo "$instance" > .cleanup_info/instance
+
 gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
   --boot-disk-size=$BOOT_DISK_SIZE
 
 function cleanup {
-  gcloud compute instances delete $instance --zone $ZONE --quiet
+  echo "Running cleanup via cleanup_gcp_resources.sh..."
+  bash ./cleanup_gcp_resources.sh
 }
 trap cleanup EXIT
 

--- a/ann_benchmark_gcp.sh
+++ b/ann_benchmark_gcp.sh
@@ -10,7 +10,10 @@ OS="ubuntu-2204-lts"
 MULTIVECTOR_DATASET=${MULTIVECTOR_DATASET:-"false"}
 MULTIVECTOR_IMPLEMENTATION=${MULTIVECTOR_IMPLEMENTATION:-"regular"}
 
-instance="benchmark-$(uuidgen | tr [:upper:] [:lower:])"
+# Generate deterministic instance name using GITHUB_RUN_ID + random string
+run_id=${GITHUB_RUN_ID:-"local"}
+random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
+instance="benchmark-${run_id}-${random_suffix}"
 
 # Create cleanup info directory and save cleanup information
 mkdir -p .cleanup_info

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -15,22 +15,33 @@ region="eu-central-1"
 run_id=$(uuidgen | tr [:upper:] [:lower:])
 key_id="key-$run_id"
 
+# Create cleanup info directory and save region info
+mkdir -p .cleanup_info
+echo "$region" > .cleanup_info/region
+
 vpc_id=$(aws ec2 describe-vpcs --region $region | jq -r '.Vpcs[0].VpcId')
 
 # subnet_id=$( aws ec2 describe-subnets --region $region --filters=Name=vpc-id,Values=$vpc_id | jq -r '.Subnets[3].SubnetId')
 
 group_id=$(aws ec2 create-security-group --group-name "benchmark-run-$run_id" --description "created for benchmark run $run_id" --vpc-id $vpc_id --region $region | jq -r '.GroupId'
 )
+# Save group_id for cleanup
+echo "$group_id" > .cleanup_info/group_id
+
 aws ec2 authorize-security-group-ingress --ip-permissions '[ { "IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "IpRanges": [ { "CidrIp": "0.0.0.0/0" } ] } ]' --group-id $group_id --region $region | jq
 
 ami=$(aws ec2 describe-images --region $region --owner amazon --filter "Name=name,Values=ubuntu/images/hvm-ssd/ubuntu*22.04*${ARCH}*" | jq -r '.Images[0].ImageId')
 
 aws ec2 create-key-pair --key-name "$key_id" --region "$region" | jq -r '.KeyMaterial' > "${key_id}.pem"
 chmod 600 "${key_id}.pem"
+# Save key_id for cleanup
+echo "$key_id" > .cleanup_info/key_id
 
 instance_id=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $MACHINE_TYPE --key-name $key_id --security-group-ids $group_id  --region $region --associate-public-ip-address --cli-read-timeout 600 --ebs-optimized --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" | jq -r '.Instances[0].InstanceId' )
 
 echo "instance ready: $instance_id"
+# Save instance_id for cleanup
+echo "$instance_id" > .cleanup_info/instance_id
 
 function cleanup() {
   set +e  # Continue cleanup even if individual commands fail
@@ -80,6 +91,9 @@ function cleanup() {
       sleep 10
     done
   fi
+
+  # Clean up info files
+  rm -rf .cleanup_info
 }
 trap cleanup EXIT SIGINT SIGTERM ERR
 

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -11,8 +11,10 @@ distance=${DISTANCE:-"l2-squared"}
 
 region="eu-central-1"
 
-# to make sure all aws resources are unique
-run_id=$(uuidgen | tr [:upper:] [:lower:])
+# Generate deterministic run_id using GITHUB_RUN_ID + random string
+github_run_id=${GITHUB_RUN_ID:-"local"}
+random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
+run_id="${github_run_id}-${random_suffix}"
 key_id="key-$run_id"
 
 # Create cleanup info directory and save region info

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -15,7 +15,7 @@ region="eu-central-1"
 github_run_id=${GITHUB_RUN_ID:-"local"}
 random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
 run_id="${github_run_id}-${random_suffix}"
-key_id="key-$run_id"
+key_id="benchmark-${run_id}"
 
 # Create cleanup info directory and save region info
 mkdir -p .cleanup_info
@@ -39,8 +39,7 @@ chmod 600 "${key_id}.pem"
 # Save key_id for cleanup
 echo "$key_id" > .cleanup_info/key_id
 
-instance_id=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $MACHINE_TYPE --key-name $key_id --security-group-ids $group_id  --region $region --associate-public-ip-address --cli-read-timeout 600 --ebs-optimized --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" | jq -r '.Instances[0].InstanceId' )
-
+instance_id=$(aws ec2 run-instances \ --image-id $ami \ --count 1 \ --instance-type $MACHINE_TYPE \ --key-name $key_id \ --security-group-ids $group_id \ --region $region \ --associate-public-ip-address \ --ebs-optimized \ --block-device-mappings "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" \ --instance-initiated-shutdown-behavior terminate \ --user-data '#!/bin/bash shutdown -h +240' \ | jq -r '.Instances[0].InstanceId')
 echo "instance ready: $instance_id"
 # Save instance_id for cleanup
 echo "$instance_id" > .cleanup_info/instance_id

--- a/ann_benchmark_quantization_aws.sh
+++ b/ann_benchmark_quantization_aws.sh
@@ -15,7 +15,7 @@ region="eu-central-1"
 github_run_id=${GITHUB_RUN_ID:-"local"}
 random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
 run_id="${github_run_id}-${random_suffix}"
-key_id="benchmark-${run_id}"
+key_id="key-$run_id"
 
 # Create cleanup info directory and save region info
 mkdir -p .cleanup_info
@@ -39,7 +39,8 @@ chmod 600 "${key_id}.pem"
 # Save key_id for cleanup
 echo "$key_id" > .cleanup_info/key_id
 
-instance_id=$(aws ec2 run-instances \ --image-id $ami \ --count 1 \ --instance-type $MACHINE_TYPE \ --key-name $key_id \ --security-group-ids $group_id \ --region $region \ --associate-public-ip-address \ --ebs-optimized \ --block-device-mappings "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" \ --instance-initiated-shutdown-behavior terminate \ --user-data '#!/bin/bash shutdown -h +240' \ | jq -r '.Instances[0].InstanceId')
+instance_id=$(aws ec2 run-instances --image-id $ami --count 1 --instance-type $MACHINE_TYPE --key-name $key_id --security-group-ids $group_id  --region $region --associate-public-ip-address --cli-read-timeout 600 --ebs-optimized --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 120 } } ]" | jq -r '.Instances[0].InstanceId' )
+
 echo "instance ready: $instance_id"
 # Save instance_id for cleanup
 echo "$instance_id" > .cleanup_info/instance_id

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -11,13 +11,19 @@ export OS="ubuntu-2204-lts"
 
 instance="benchmark-$(uuidgen | tr [:upper:] [:lower:])"
 
+# Create cleanup info directory and save cleanup information
+mkdir -p .cleanup_info
+echo "$ZONE" > .cleanup_info/zone
+echo "$instance" > .cleanup_info/instance
+
 gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
   --boot-disk-size=$BOOT_DISK_SIZE
 
 function cleanup {
-  gcloud compute instances delete $instance --quiet --zone $ZONE
+  echo "Running cleanup via cleanup_gcp_resources.sh..."
+  bash ./cleanup_gcp_resources.sh
 }
 trap cleanup EXIT
 

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -23,7 +23,8 @@ gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
   --boot-disk-size=$BOOT_DISK_SIZE \
-  --max-run-duration=4h
+  --max-run-duration=4h \
+  --instance-termination-action=DELETE
 
 function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -9,7 +9,10 @@ MULTIVECTOR_DATASET=${MULTIVECTOR_DATASET:-"false"}
 export CLOUD_PROVIDER="gcp"
 export OS="ubuntu-2204-lts"
 
-instance="benchmark-$(uuidgen | tr [:upper:] [:lower:])"
+# Generate deterministic instance name using GITHUB_RUN_ID + random string
+run_id=${GITHUB_RUN_ID:-"local"}
+random_suffix=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
+instance="benchmark-${run_id}-${random_suffix}"
 
 # Create cleanup info directory and save cleanup information
 mkdir -p .cleanup_info

--- a/ann_benchmark_quantization_gcp.sh
+++ b/ann_benchmark_quantization_gcp.sh
@@ -22,7 +22,8 @@ echo "$instance" > .cleanup_info/instance
 gcloud compute instances create $instance \
   --image-family=$OS --image-project=ubuntu-os-cloud \
   --machine-type=$MACHINE_TYPE --zone $ZONE \
-  --boot-disk-size=$BOOT_DISK_SIZE
+  --boot-disk-size=$BOOT_DISK_SIZE \
+  --max-run-duration=4h
 
 function cleanup {
   echo "Running cleanup via cleanup_gcp_resources.sh..."

--- a/cleanup_aws_resources.sh
+++ b/cleanup_aws_resources.sh
@@ -4,6 +4,11 @@ set +e  # Continue cleanup even if individual commands fail
 
 echo "Running AWS resources cleanup..."
 
+# Set timeout for AWS CLI commands
+export AWS_CLI_READ_TIMEOUT=30
+export AWS_CLI_CONNECT_TIMEOUT=10
+export AWS_MAX_ATTEMPTS=3
+
 # Check if cleanup info directory exists
 if [ ! -d ".cleanup_info" ]; then
   echo "No cleanup info found. Skipping cleanup."
@@ -19,55 +24,93 @@ else
   exit 0
 fi
 
+# Function to run AWS command with timeout
+run_with_timeout() {
+  local timeout_duration=$1
+  shift
+  timeout "$timeout_duration" "$@"
+  return $?
+}
+
 # Cleanup instance
 if [ -f ".cleanup_info/instance_id" ]; then
   instance_id=$(cat .cleanup_info/instance_id)
   echo "Terminating instance $instance_id"
-  aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" | jq || true
+  
+  # Terminate instance with timeout
+  if run_with_timeout 60s aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" --output json; then
+    echo "Terminate command completed successfully"
+  else
+    echo "Terminate command failed or timed out, but continuing..."
+  fi
 
+  # Wait for instance termination with timeout
   echo "Waiting for instance to terminate..."
   SECONDS=0
-  timeout=300
+  timeout=240  # Reduced timeout
   while [ $SECONDS -lt $timeout ]; do
-    status=$(aws ec2 describe-instances --instance-ids "$instance_id" --region "$region" 2>/dev/null | jq -r '.Reservations[0].Instances[0].State.Name' 2>/dev/null || echo "error")
+    echo "Checking instance status... ($SECONDS/${timeout}s)"
+    status=$(run_with_timeout 30s aws ec2 describe-instances --instance-ids "$instance_id" --region "$region" --output json 2>/dev/null | jq -r '.Reservations[0].Instances[0].State.Name' 2>/dev/null || echo "error")
+    
     if [ "$status" = "terminated" ]; then
       echo "Instance successfully terminated"
       break
     elif [ "$status" = "error" ]; then
-      echo "Instance not found - assuming terminated"
+      echo "Instance not found or describe command failed - assuming terminated"
       break
     fi
     echo "Instance status: $status"
-    sleep 5
-    SECONDS=$((SECONDS + 5))
+    sleep 10
+    SECONDS=$((SECONDS + 10))
   done
 
   if [ $SECONDS -ge $timeout ]; then
-    echo "Warning: Timeout waiting for instance termination. Please check AWS instances for manual cleanup."
+    echo "Warning: Timeout waiting for instance termination confirmation."
+    echo "The instance may still be terminating. Please check AWS console: $instance_id in region $region"
   fi
+else
+  echo "No instance info found in cleanup files"
 fi
 
 # Cleanup key pair
 if [ -f ".cleanup_info/key_id" ]; then
   key_id=$(cat .cleanup_info/key_id)
   echo "Deleting key pair $key_id"
-  aws ec2 delete-key-pair --key-name "$key_id" --region "$region" | jq || true
+  
+  if run_with_timeout 30s aws ec2 delete-key-pair --key-name "$key_id" --region "$region" --output json; then
+    echo "Key pair deleted successfully"
+  else
+    echo "Key pair deletion failed or timed out"
+  fi
+  
+  # Clean up local key file
   rm -f "${key_id}.pem" || true
+else
+  echo "No key pair info found in cleanup files"
 fi
 
 # Cleanup security group
 if [ -f ".cleanup_info/group_id" ]; then
   group_id=$(cat .cleanup_info/group_id)
   echo "Deleting security group $group_id"
+  
   # Add retry loop for security group deletion since it might fail if instance is still terminating
   for i in {1..6}; do
-    if aws ec2 delete-security-group --group-id "$group_id" --region "$region" 2>/dev/null | jq; then
+    echo "Attempting security group deletion (attempt $i/6)..."
+    if run_with_timeout 30s aws ec2 delete-security-group --group-id "$group_id" --region "$region" --output json; then
       echo "Security group deleted successfully"
       break
+    else
+      if [ $i -lt 6 ]; then
+        echo "Security group deletion failed or timed out, retrying in 10 seconds..."
+        sleep 10
+      else
+        echo "Security group deletion failed after all attempts"
+      fi
     fi
-    echo "Retrying security group deletion in 10 seconds... (attempt $i/6)"
-    sleep 10
   done
+else
+  echo "No security group info found in cleanup files"
 fi
 
 # Clean up info files

--- a/cleanup_aws_resources.sh
+++ b/cleanup_aws_resources.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set +e  # Continue cleanup even if individual commands fail
+
+echo "Running AWS resources cleanup..."
+
+# Check if cleanup info directory exists
+if [ ! -d ".cleanup_info" ]; then
+  echo "No cleanup info found. Skipping cleanup."
+  exit 0
+fi
+
+# Read cleanup variables from files
+if [ -f ".cleanup_info/region" ]; then
+  region=$(cat .cleanup_info/region)
+  echo "Using region: $region"
+else
+  echo "No region info found. Skipping cleanup."
+  exit 0
+fi
+
+# Cleanup instance
+if [ -f ".cleanup_info/instance_id" ]; then
+  instance_id=$(cat .cleanup_info/instance_id)
+  echo "Terminating instance $instance_id"
+  aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" | jq || true
+
+  # Busy loop to wait for instance termination with timeout
+  echo "Waiting for instance to terminate..."
+  SECONDS=0
+  timeout=300
+  while [ $SECONDS -lt $timeout ]; do
+    status=$(aws ec2 describe-instances --instance-ids "$instance_id" --region "$region" 2>/dev/null | jq -r '.Reservations[0].Instances[0].State.Name' 2>/dev/null || echo "error")
+    if [ "$status" = "terminated" ]; then
+      echo "Instance successfully terminated"
+      break
+    elif [ "$status" = "error" ]; then
+      echo "Instance not found - assuming terminated"
+      break
+    fi
+    echo "Instance status: $status"
+    sleep 5
+    SECONDS=$((SECONDS + 5))
+  done
+
+  if [ $SECONDS -ge $timeout ]; then
+    echo "Warning: Timeout waiting for instance termination. Please check AWS instances for manual cleanup."
+  fi
+fi
+
+# Cleanup key pair
+if [ -f ".cleanup_info/key_id" ]; then
+  key_id=$(cat .cleanup_info/key_id)
+  echo "Deleting key pair $key_id"
+  aws ec2 delete-key-pair --key-name "$key_id" --region "$region" | jq || true
+  rm -f "${key_id}.pem" || true
+fi
+
+# Cleanup security group
+if [ -f ".cleanup_info/group_id" ]; then
+  group_id=$(cat .cleanup_info/group_id)
+  echo "Deleting security group $group_id"
+  # Add retry loop for security group deletion since it might fail if instance is still terminating
+  for i in {1..6}; do
+    if aws ec2 delete-security-group --group-id "$group_id" --region "$region" 2>/dev/null | jq; then
+      echo "Security group deleted successfully"
+      break
+    fi
+    echo "Retrying security group deletion in 10 seconds... (attempt $i/6)"
+    sleep 10
+  done
+fi
+
+# Clean up info files
+rm -rf .cleanup_info
+
+echo "AWS cleanup completed" 

--- a/cleanup_aws_resources.sh
+++ b/cleanup_aws_resources.sh
@@ -25,7 +25,6 @@ if [ -f ".cleanup_info/instance_id" ]; then
   echo "Terminating instance $instance_id"
   aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" | jq || true
 
-  # Busy loop to wait for instance termination with timeout
   echo "Waiting for instance to terminate..."
   SECONDS=0
   timeout=300

--- a/cleanup_aws_resources.sh
+++ b/cleanup_aws_resources.sh
@@ -4,11 +4,6 @@ set +e  # Continue cleanup even if individual commands fail
 
 echo "Running AWS resources cleanup..."
 
-# Set timeout for AWS CLI commands
-export AWS_CLI_READ_TIMEOUT=30
-export AWS_CLI_CONNECT_TIMEOUT=10
-export AWS_MAX_ATTEMPTS=3
-
 # Check if cleanup info directory exists
 if [ ! -d ".cleanup_info" ]; then
   echo "No cleanup info found. Skipping cleanup."
@@ -24,93 +19,55 @@ else
   exit 0
 fi
 
-# Function to run AWS command with timeout
-run_with_timeout() {
-  local timeout_duration=$1
-  shift
-  timeout "$timeout_duration" "$@"
-  return $?
-}
-
 # Cleanup instance
 if [ -f ".cleanup_info/instance_id" ]; then
   instance_id=$(cat .cleanup_info/instance_id)
   echo "Terminating instance $instance_id"
-  
-  # Terminate instance with timeout
-  if run_with_timeout 60s aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" --output json; then
-    echo "Terminate command completed successfully"
-  else
-    echo "Terminate command failed or timed out, but continuing..."
-  fi
+  aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" | jq || true
 
-  # Wait for instance termination with timeout
   echo "Waiting for instance to terminate..."
   SECONDS=0
-  timeout=240  # Reduced timeout
+  timeout=300
   while [ $SECONDS -lt $timeout ]; do
-    echo "Checking instance status... ($SECONDS/${timeout}s)"
-    status=$(run_with_timeout 30s aws ec2 describe-instances --instance-ids "$instance_id" --region "$region" --output json 2>/dev/null | jq -r '.Reservations[0].Instances[0].State.Name' 2>/dev/null || echo "error")
-    
+    status=$(aws ec2 describe-instances --instance-ids "$instance_id" --region "$region" 2>/dev/null | jq -r '.Reservations[0].Instances[0].State.Name' 2>/dev/null || echo "error")
     if [ "$status" = "terminated" ]; then
       echo "Instance successfully terminated"
       break
     elif [ "$status" = "error" ]; then
-      echo "Instance not found or describe command failed - assuming terminated"
+      echo "Instance not found - assuming terminated"
       break
     fi
     echo "Instance status: $status"
-    sleep 10
-    SECONDS=$((SECONDS + 10))
+    sleep 5
+    SECONDS=$((SECONDS + 5))
   done
 
   if [ $SECONDS -ge $timeout ]; then
-    echo "Warning: Timeout waiting for instance termination confirmation."
-    echo "The instance may still be terminating. Please check AWS console: $instance_id in region $region"
+    echo "Warning: Timeout waiting for instance termination. Please check AWS instances for manual cleanup."
   fi
-else
-  echo "No instance info found in cleanup files"
 fi
 
 # Cleanup key pair
 if [ -f ".cleanup_info/key_id" ]; then
   key_id=$(cat .cleanup_info/key_id)
   echo "Deleting key pair $key_id"
-  
-  if run_with_timeout 30s aws ec2 delete-key-pair --key-name "$key_id" --region "$region" --output json; then
-    echo "Key pair deleted successfully"
-  else
-    echo "Key pair deletion failed or timed out"
-  fi
-  
-  # Clean up local key file
+  aws ec2 delete-key-pair --key-name "$key_id" --region "$region" | jq || true
   rm -f "${key_id}.pem" || true
-else
-  echo "No key pair info found in cleanup files"
 fi
 
 # Cleanup security group
 if [ -f ".cleanup_info/group_id" ]; then
   group_id=$(cat .cleanup_info/group_id)
   echo "Deleting security group $group_id"
-  
   # Add retry loop for security group deletion since it might fail if instance is still terminating
   for i in {1..6}; do
-    echo "Attempting security group deletion (attempt $i/6)..."
-    if run_with_timeout 30s aws ec2 delete-security-group --group-id "$group_id" --region "$region" --output json; then
+    if aws ec2 delete-security-group --group-id "$group_id" --region "$region" 2>/dev/null | jq; then
       echo "Security group deleted successfully"
       break
-    else
-      if [ $i -lt 6 ]; then
-        echo "Security group deletion failed or timed out, retrying in 10 seconds..."
-        sleep 10
-      else
-        echo "Security group deletion failed after all attempts"
-      fi
     fi
+    echo "Retrying security group deletion in 10 seconds... (attempt $i/6)"
+    sleep 10
   done
-else
-  echo "No security group info found in cleanup files"
 fi
 
 # Clean up info files

--- a/cleanup_cancelled_aws_resources.sh
+++ b/cleanup_cancelled_aws_resources.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+set +e  # Continue cleanup even if individual commands fail
+
+echo "Running cleanup for cancelled AWS resources..."
+
+# Get the run ID
+github_run_id=${GITHUB_RUN_ID:-""}
+if [ -z "$github_run_id" ]; then
+  echo "No GITHUB_RUN_ID found. Cannot proceed with cleanup."
+  exit 0
+fi
+
+echo "Cleaning up resources for run ID: $github_run_id"
+
+# Default region used in the benchmarking scripts
+region="eu-central-1"
+
+# Find all security groups and instances that start with our run ID
+run_id_prefix="${github_run_id}-"
+echo "Looking for resources with run ID prefix: $run_id_prefix"
+
+resources_found=false
+
+# Find and terminate instances
+echo "Looking for instances with security groups named 'benchmark-run-${run_id_prefix}*'"
+instances=$(aws ec2 describe-instances \
+  --region "$region" \
+  --filters "Name=instance-state-name,Values=running,pending,stopped,stopping" \
+  --query "Reservations[*].Instances[?starts_with(SecurityGroups[0].GroupName, 'benchmark-run-${run_id_prefix}')].InstanceId" \
+  --output text 2>/dev/null || true)
+
+if [ -n "$instances" ] && [ "$instances" != "None" ]; then
+  resources_found=true
+  echo "Found instances to terminate:"
+  echo "$instances"
+  
+  for instance_id in $instances; do
+    echo "Terminating instance: $instance_id"
+    aws ec2 terminate-instances --instance-ids "$instance_id" --region "$region" || {
+      echo "Failed to terminate instance $instance_id, continuing..."
+    }
+  done
+  
+  # Wait for instances to terminate before cleaning up other resources
+  echo "Waiting for instances to terminate..."
+  aws ec2 wait instance-terminated --instance-ids $instances --region "$region" || {
+    echo "Timeout waiting for instances to terminate, continuing with cleanup..."
+  }
+fi
+
+# Find and delete security groups
+echo "Looking for security groups named 'benchmark-run-${run_id_prefix}*'"
+security_groups=$(aws ec2 describe-security-groups \
+  --region "$region" \
+  --filters "Name=group-name,Values=benchmark-run-${run_id_prefix}*" \
+  --query "SecurityGroups[].GroupId" \
+  --output text 2>/dev/null || true)
+
+if [ -n "$security_groups" ] && [ "$security_groups" != "None" ]; then
+  resources_found=true
+  echo "Found security groups to delete:"
+  echo "$security_groups"
+  
+  for group_id in $security_groups; do
+    echo "Deleting security group: $group_id"
+    aws ec2 delete-security-group --group-id "$group_id" --region "$region" || {
+      echo "Failed to delete security group $group_id, continuing..."
+    }
+    sleep 2
+  done
+fi
+
+# Find and delete key pairs
+echo "Looking for key pairs named 'key-${run_id_prefix}*'"
+key_pairs=$(aws ec2 describe-key-pairs \
+  --region "$region" \
+  --filters "Name=key-name,Values=key-${run_id_prefix}*" \
+  --query "KeyPairs[].KeyName" \
+  --output text 2>/dev/null || true)
+
+if [ -n "$key_pairs" ] && [ "$key_pairs" != "None" ]; then
+  resources_found=true
+  echo "Found key pairs to delete:"
+  echo "$key_pairs"
+  
+  for key_name in $key_pairs; do
+    echo "Deleting key pair: $key_name"
+    aws ec2 delete-key-pair --key-name "$key_name" --region "$region" || {
+      echo "Failed to delete key pair $key_name, continuing..."
+    }
+    # Also remove local pem file if it exists
+    rm -f "${key_name}.pem" || true
+  done
+fi
+
+if [ "$resources_found" = false ]; then
+  echo "No AWS resources found with run ID prefix: $run_id_prefix"
+fi
+
+echo "Cleanup for cancelled AWS resources completed" 

--- a/cleanup_cancelled_gcp_instances.sh
+++ b/cleanup_cancelled_gcp_instances.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set +e  # Continue cleanup even if individual commands fail
+
+echo "Running cleanup for cancelled GCP instances..."
+
+# Get the run ID
+run_id=${GITHUB_RUN_ID:-""}
+if [ -z "$run_id" ]; then
+  echo "No GITHUB_RUN_ID found. Cannot proceed with cleanup."
+  exit 0
+fi
+
+echo "Cleaning up instances for run ID: $run_id"
+
+# Common zones used in the benchmarking scripts
+zones=("us-central1-a" "us-central1-b" "us-central1-c" "us-east1-a" "us-west1-a")
+
+# Find all instances that start with "benchmark-${run_id}-"
+instance_prefix="benchmark-${run_id}-"
+echo "Looking for instances with prefix: $instance_prefix"
+
+instances_found=false
+
+# Search in all zones
+for zone in "${zones[@]}"; do
+  echo "Checking zone: $zone"
+  
+  # Get list of instances matching the pattern in this zone
+  instances=$(gcloud compute instances list --zones="$zone" --filter="name:${instance_prefix}*" --format="value(name)" 2>/dev/null || true)
+  
+  if [ -n "$instances" ]; then
+    instances_found=true
+    echo "Found instances in zone $zone:"
+    echo "$instances"
+    
+    # Delete each instance
+    for instance in $instances; do
+      echo "Deleting instance: $instance in zone $zone"
+      gcloud compute instances delete "$instance" --zone="$zone" --quiet || {
+        echo "Failed to delete instance $instance in zone $zone, continuing..."
+      }
+      
+      # Wait a bit to avoid API rate limits
+      sleep 2
+    done
+  fi
+done
+
+if [ "$instances_found" = false ]; then
+  echo "No instances found with prefix: $instance_prefix in any zone"
+fi
+
+echo "Cleanup for cancelled instances completed" 

--- a/cleanup_gcp_resources.sh
+++ b/cleanup_gcp_resources.sh
@@ -4,6 +4,10 @@ set +e  # Continue cleanup even if individual commands fail
 
 echo "Running GCP resources cleanup..."
 
+# Set timeout for gcloud commands
+export CLOUDSDK_CORE_DISABLE_PROMPTS=1
+export CLOUDSDK_CORE_REQUEST_TIMEOUT=30
+
 # Check if cleanup info directory exists
 if [ ! -d ".cleanup_info" ]; then
   echo "No cleanup info found. Skipping cleanup."
@@ -19,36 +23,55 @@ else
   exit 0
 fi
 
+# Function to run gcloud command with timeout
+run_with_timeout() {
+  local timeout_duration=$1
+  shift
+  timeout "$timeout_duration" "$@"
+  return $?
+}
+
 # Cleanup instance
 if [ -f ".cleanup_info/instance" ]; then
   instance=$(cat .cleanup_info/instance)
   echo "Deleting GCP instance: $instance"
   
-  # Check if instance exists before trying to delete it
-  if gcloud compute instances describe "$instance" --zone="$zone" &>/dev/null; then
+  # Check if instance exists before trying to delete it (with timeout)
+  echo "Checking if instance exists..."
+  if run_with_timeout 30s gcloud compute instances describe "$instance" --zone="$zone" --format="value(name)" &>/dev/null; then
     echo "Instance exists, proceeding with deletion..."
-    gcloud compute instances delete "$instance" --zone="$zone" --quiet || true
+    
+    # Delete instance with timeout
+    echo "Deleting instance..."
+    if run_with_timeout 60s gcloud compute instances delete "$instance" --zone="$zone" --quiet; then
+      echo "Delete command completed successfully"
+    else
+      echo "Delete command failed or timed out, but continuing..."
+    fi
     
     # Wait for instance deletion with timeout
     echo "Waiting for instance to be deleted..."
     SECONDS=0
-    timeout=180
+    timeout=120  # Reduced timeout
     while [ $SECONDS -lt $timeout ]; do
-      if ! gcloud compute instances describe "$instance" --zone="$zone" &>/dev/null; then
+      if ! run_with_timeout 15s gcloud compute instances describe "$instance" --zone="$zone" --format="value(name)" &>/dev/null; then
         echo "Instance successfully deleted"
         break
       fi
-      echo "Instance still exists, waiting..."
-      sleep 5
-      SECONDS=$((SECONDS + 5))
+      echo "Instance still exists, waiting... ($SECONDS/${timeout}s)"
+      sleep 10
+      SECONDS=$((SECONDS + 10))
     done
     
     if [ $SECONDS -ge $timeout ]; then
-      echo "Warning: Timeout waiting for instance deletion. Please check GCP console for manual cleanup."
+      echo "Warning: Timeout waiting for instance deletion confirmation."
+      echo "The instance may still be deleting. Please check GCP console: $instance in zone $zone"
     fi
   else
-    echo "Instance not found - assuming already deleted"
+    echo "Instance not found or describe command failed - assuming already deleted or doesn't exist"
   fi
+else
+  echo "No instance info found in cleanup files"
 fi
 
 # Clean up info files

--- a/cleanup_gcp_resources.sh
+++ b/cleanup_gcp_resources.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set +e  # Continue cleanup even if individual commands fail
+
+echo "Running GCP resources cleanup..."
+
+# Check if cleanup info directory exists
+if [ ! -d ".cleanup_info" ]; then
+  echo "No cleanup info found. Skipping cleanup."
+  exit 0
+fi
+
+# Read cleanup variables from files
+if [ -f ".cleanup_info/zone" ]; then
+  zone=$(cat .cleanup_info/zone)
+  echo "Using zone: $zone"
+else
+  echo "No zone info found. Skipping cleanup."
+  exit 0
+fi
+
+# Cleanup instance
+if [ -f ".cleanup_info/instance" ]; then
+  instance=$(cat .cleanup_info/instance)
+  echo "Deleting GCP instance: $instance"
+  
+  # Check if instance exists before trying to delete it
+  if gcloud compute instances describe "$instance" --zone="$zone" &>/dev/null; then
+    echo "Instance exists, proceeding with deletion..."
+    gcloud compute instances delete "$instance" --zone="$zone" --quiet || true
+    
+    # Wait for instance deletion with timeout
+    echo "Waiting for instance to be deleted..."
+    SECONDS=0
+    timeout=180
+    while [ $SECONDS -lt $timeout ]; do
+      if ! gcloud compute instances describe "$instance" --zone="$zone" &>/dev/null; then
+        echo "Instance successfully deleted"
+        break
+      fi
+      echo "Instance still exists, waiting..."
+      sleep 5
+      SECONDS=$((SECONDS + 5))
+    done
+    
+    if [ $SECONDS -ge $timeout ]; then
+      echo "Warning: Timeout waiting for instance deletion. Please check GCP console for manual cleanup."
+    fi
+  else
+    echo "Instance not found - assuming already deleted"
+  fi
+fi
+
+# Clean up info files
+rm -rf .cleanup_info
+
+echo "GCP cleanup completed" 


### PR DESCRIPTION
In some circumstances, the CI jobs don't finish gracefully and that may leave ANN VM running because they weren't clean up automatically.

This PR brings some improvements in that regard:
- Create cleanup script files to be shared across jobs/steps
- Run cleanup steps at the end of every ANN benchmark job, no matter the result
- Additionally, add a final job in the overall pipeline to delete instances
- Now, instances have a name related to the Job ID, to facilitate tracking and cleanup
- Set max up time of 4 hours
- Make both things for AWS and GCP