### PR TITLE
Add RAFT_BOOTSTRAP_TIMEOUT to upgrade_journey.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -740,7 +740,7 @@ jobs:
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
       NUM_NODES: 1
-      MINIMUM_WEAVIATE_VERSION: 1.22.0
+      MINIMUM_WEAVIATE_VERSION: 1.29.0
     steps:
       - uses: actions/checkout@v3
       # - name: Polar Signals Continuous Profiling
@@ -767,7 +767,7 @@ jobs:
     env:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
       NUM_NODES: 3
-      MINIMUM_WEAVIATE_VERSION: 1.22.0
+      MINIMUM_WEAVIATE_VERSION: 1.29.0
     steps:
       - uses: actions/checkout@v3
       # - name: Polar Signals Continuous Profiling

--- a/apps/upgrade-journey/containers.go
+++ b/apps/upgrade-journey/containers.go
@@ -124,6 +124,7 @@ func (c *cluster) startWeaviateNode(ctx context.Context, nodeId int, version str
 				"CLUSTER_JOIN":                            fmt.Sprintf("%s:7100", c.hostname(0)),
 				"RAFT_JOIN":                               c.hostname(0),
 				"RAFT_BOOTSTRAP_EXPECT":                   "1",
+				"RAFT_BOOTSTRAP_TIMEOUT":                  "300",
 				"PERSISTENCE_LSM_ACCESS_STRATEGY":         os.Getenv("PERSISTENCE_LSM_ACCESS_STRATEGY"),
 			},
 			Mounts: testcontainers.Mounts(testcontainers.BindMount(
@@ -167,7 +168,7 @@ func (c *cluster) getStartupTimeout() time.Duration {
 	// For multi-node clusters, increase timeout based on node count
 	// Each additional node adds 30 seconds to account for cluster joining time
 	if c.nodeCount > 1 {
-		return baseTimeout + time.Duration(c.nodeCount)*30*time.Second
+		return baseTimeout + time.Duration(c.nodeCount)*60*time.Second
 	}
 
 	return baseTimeout


### PR DESCRIPTION
The upgrade journey containers were missing the RAFT_BOOTSTRAP_TIMEOUT parameter. Adding it.