### PR TITLE
fix: harden goroutine-leak check against shared-runner contention

### DIFF
--- a/apps/goroutine-leak-on-class-delete/run.py
+++ b/apps/goroutine-leak-on-class-delete/run.py
@@ -18,13 +18,13 @@ class StressTest:
 
     def run(self, iterations: int, start_checking: int, rolling_median_count: int):
         for i in range(iterations):
-            before_all = time.time()
+            before_all = time.monotonic()
             col = client.collections.create("BuggyBugBug")
             col.data.insert(properties={"hello": "world"}, uuid=uuid.UUID(int=1))
             col.data.replace(properties={"goodbye": "blue skies"}, uuid=uuid.UUID(int=1))
             col.data.delete_by_id(uuid.UUID(int=1))
             client.collections.delete("BuggyBugBug")
-            took = time.time() - before_all
+            took = time.monotonic() - before_all
             self.durations.append(took)
             if i % 100 == 0:
                 logger.info(f"[It={i:05}] Cycle took {timedelta(seconds=took)}")

--- a/apps/goroutine-leak-on-class-delete/run.py
+++ b/apps/goroutine-leak-on-class-delete/run.py
@@ -32,9 +32,7 @@ class StressTest:
                     self.analyze(start_checking, rolling_average_count)
 
     def analyze(self, lower_count, upper_count):
-        # Medians instead of means: CPU contention on shared runners adds
-        # isolated slow cycles that inflate a mean, while a leak slows every
-        # cycle and moves the median too.
+        # Medians: runner-contention outliers inflate a mean; a leak slows every cycle.
         median_lower = median(self.durations[:lower_count])
         median_upper = median(self.durations[(len(self.durations) - upper_count) :])
 
@@ -48,8 +46,7 @@ class StressTest:
         # keep the check one-sided rather than using abs().
         ratio = (median_upper - median_lower) / median_lower
 
-        # A leak never recovers, so only fail once the breach persists across
-        # consecutive checks; a contention burst clears within one window.
+        # A leak never recovers; a contention burst clears within one window.
         if ratio > 0.3:
             self.breaches += 1
             logger.warning(

--- a/apps/goroutine-leak-on-class-delete/run.py
+++ b/apps/goroutine-leak-on-class-delete/run.py
@@ -16,7 +16,7 @@ class StressTest:
         self.durations = []
         self.breaches = 0
 
-    def run(self, iterations: int, start_checking: int, rolling_average_count: int):
+    def run(self, iterations: int, start_checking: int, rolling_median_count: int):
         for i in range(iterations):
             before_all = time.time()
             col = client.collections.create("BuggyBugBug")
@@ -29,7 +29,7 @@ class StressTest:
             if i % 100 == 0:
                 logger.info(f"[It={i:05}] Cycle took {timedelta(seconds=took)}")
                 if i > start_checking:
-                    self.analyze(start_checking, rolling_average_count)
+                    self.analyze(start_checking, rolling_median_count)
 
     def analyze(self, lower_count, upper_count):
         # Medians: runner-contention outliers inflate a mean; a leak slows every cycle.
@@ -50,7 +50,7 @@ class StressTest:
         if ratio > 0.3:
             self.breaches += 1
             logger.warning(
-                f"rolling median is too much slower than control: {ratio * 100}% (breach {self.breaches}/3)"
+                f"rolling median is too much slower than control: {ratio * 100:.1f}% (breach {self.breaches}/3)"
             )
             if self.breaches >= 3:
                 logger.error("slowdown persisted across 3 consecutive checks, failing")
@@ -59,4 +59,4 @@ class StressTest:
             self.breaches = 0
 
 
-StressTest().run(iterations=15_000, start_checking=1000, rolling_average_count=250)
+StressTest().run(iterations=15_000, start_checking=1000, rolling_median_count=250)

--- a/apps/goroutine-leak-on-class-delete/run.py
+++ b/apps/goroutine-leak-on-class-delete/run.py
@@ -4,6 +4,7 @@ import uuid
 import time
 from loguru import logger
 from datetime import timedelta
+from statistics import median
 import sys
 
 client = weaviate.connect_to_local()
@@ -13,6 +14,7 @@ client.collections.delete_all()
 class StressTest:
     def __init__(self):
         self.durations = []
+        self.breaches = 0
 
     def run(self, iterations: int, start_checking: int, rolling_average_count: int):
         for i in range(iterations):
@@ -30,26 +32,34 @@ class StressTest:
                     self.analyze(start_checking, rolling_average_count)
 
     def analyze(self, lower_count, upper_count):
-        mean_lower = mean(self.durations[:lower_count])
-        mean_upper = mean(self.durations[(len(self.durations) - upper_count) :])
+        # Medians instead of means: CPU contention on shared runners adds
+        # isolated slow cycles that inflate a mean, while a leak slows every
+        # cycle and moves the median too.
+        median_lower = median(self.durations[:lower_count])
+        median_upper = median(self.durations[(len(self.durations) - upper_count) :])
 
         logger.info(
-            f"means: control={(mean_lower*1000):.2f}ms rolling_average={(mean_upper*1000):.2f}ms (over last {upper_count} cycles)"
+            f"medians: control={(median_lower*1000):.2f}ms rolling_median={(median_upper*1000):.2f}ms (over last {upper_count} cycles)"
         )
 
         # Only a slowdown signals the leak: a leak makes each cycle progressively
-        # slower, so the rolling average climbs above control. A faster rolling
-        # average just means the control window captured cold-start warmup, so
+        # slower, so the rolling median climbs above control. A faster rolling
+        # median just means the control window captured cold-start warmup, so
         # keep the check one-sided rather than using abs().
-        ratio = (mean_upper - mean_lower) / mean_lower
+        ratio = (median_upper - median_lower) / median_lower
 
+        # A leak never recovers, so only fail once the breach persists across
+        # consecutive checks; a contention burst clears within one window.
         if ratio > 0.3:
-            logger.error(f"rolling average is too much slower than control: {ratio * 100}%")
-            sys.exit(1)
-
-
-def mean(durs: [float]) -> float:
-    return sum(durs) / len(durs)
+            self.breaches += 1
+            logger.warning(
+                f"rolling median is too much slower than control: {ratio * 100}% (breach {self.breaches}/3)"
+            )
+            if self.breaches >= 3:
+                logger.error("slowdown persisted across 3 consecutive checks, failing")
+                sys.exit(1)
+        else:
+            self.breaches = 0
 
 
 StressTest().run(iterations=15_000, start_checking=1000, rolling_average_count=250)


### PR DESCRIPTION
## Summary

Hardens the `goroutine_leak_on_class_delete` check so shared-runner CPU contention no longer fails it, while a real leak still does.

## What the check measured before

`run.py` compared the **mean** of the last 250 cycle times against the mean of the first 1000 (control) and exited non-zero on the **first single check** where the rolling mean was >30% slower.

## Why shared-runner contention breaks that

The job runs on `ubuntu-latest` (shared 2-vCPU runner) with Weaviate capped at 1 CPU. Host contention occasionally injects isolated 300-600ms cycles into a ~170ms baseline. A burst of those inside one 250-cycle window pushes the mean past 30% even though typical cycles stay at baseline, and the check fires before the window can recover. Both recent failures show this signature (details in #438):

- **Aug 31, mmap leg** (run 33343430339): flat ~170ms for 3000 iterations, contention burst, exit at It=3200 with 47.55%. The sampled cycle at the failing check was 191ms — baseline speed. An earlier spike in the same run recovered fully. The pread leg passed with the identical nightly image.
- **Aug 25, pread leg** (run 32846868802): rolling mean oscillated 220 → 196 → 240ms, single breach at 33.5%, exit at It=8500. The mmap leg passed that day.

A goroutine leak cannot produce either trace: it slows every cycle, monotonically, and never recovers.

## Changes

- Compare **medians** instead of means. Isolated contention outliers barely move a median; a leak slows every cycle, so the median climbs with it.
- Require **3 consecutive breaches** (300 iterations) of the 30% threshold before exiting. Breaches log a warning and reset on any passing check. A leak never recovers, so the cost is delay rather than accuracy: the exit moves 200 iterations later, and a leak whose first breach lands only in the final two checks (iterations 14800/14900) is no longer caught within the run.

## Evidence

Replayed against the real `StressTest` class (module loaded with stubbed client, driving `analyze` exactly as `run()` does) using cycle sequences reconstructed from both failing runs' logs (per-100-block means from wall-clock timestamps, bimodal baseline+outlier mix matching the sampled per-cycle timings), plus a synthetic monotonic leak (+0.03ms/cycle):

| Scenario | Old check | New check |
|---|---|---|
| Aug 31 mmap contention | exit 1 at It=3200, 48.6% (CI: It=3200, 47.55%) | passes all 15k iterations |
| Aug 25 pread contention | exit 1 at It=8500, 33.2% (CI: It=8500, 33.46%) | passes all 15k iterations |
| Synthetic monotonic leak | exit 1 at It=3400 | exit 1 at It=3600 |

The old-check replays reproduce the actual CI failures at the same iteration and nearly the same ratio, so the reconstructions are faithful. The leak is still caught, 200 iterations later than before.

## Related

Closes https://github.com/weaviate/weaviate-chaos-engineering/issues/438

