### PR TITLE
ci: authenticate github.com clones in multi-tenancy chaos jobs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1660,6 +1660,11 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
+      # Without this the submodule clone is unauthenticated and shares a 60/hour limit per egress IP.
+      - name: Authenticate github.com clones
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Run chaos test
         run: ./multi_tenancy_concurrent_importing.sh
   multi_tenancy_activate_deactivate_v1_24:
@@ -1684,6 +1689,11 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
+      # Without this the submodule clone is unauthenticated and shares a 60/hour limit per egress IP.
+      - name: Authenticate github.com clones
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Run chaos test
         run: ./multi_tenancy_activate_deactivate_v1_24.sh
   multi_tenancy_activate_deactivate:
@@ -1708,6 +1718,11 @@ jobs:
           password: ${{secrets.DOCKER_PASSWORD}}
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@master
+      # Without this the submodule clone is unauthenticated and shares a 60/hour limit per egress IP.
+      - name: Authenticate github.com clones
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Run chaos test
         run: ./multi_tenancy_activate_deactivate.sh
   goroutine_leak_class_delete:


### PR DESCRIPTION
## Problem

`multi_tenancy_concurrent_importing.sh`, `multi_tenancy_activate_deactivate.sh` and `multi_tenancy_activate_deactivate_v1_24.sh` each run `git submodule update --init --remote --recursive` to fetch `multi-tenancy-load-test`. That clone is unauthenticated. Since 2026-09-02 it returns 401 on most Ubicloud runners:

```
fatal: could not read Username for 'https://github.com': No such device or address
fatal: expected flush after ref listing
fatal: clone of 'https://github.com/weaviate/multi-tenancy-load-test' into submodule path '...' failed
```

git retries once and aborts, so the job fails before the test starts. Example: [run 33697843005](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/33697843005/job/100470626991).

## Root cause

GitHub limits unauthenticated requests to 60/hour per IP, and that covers HTTPS clones. Ubicloud runners share egress IPs and do not get the exemption GitHub-hosted runners have, so the quota is consumed by other Ubicloud tenants rather than by us.

`weaviate-e2e-tests` started failing at the same time with the same error, cloning a different repo through pip instead of a submodule. Nothing changed in either repo. Full triage is in the companion PR: https://github.com/weaviate/weaviate-e2e-tests/pull/514.

## Change

Rewrite `https://github.com/` to use the job token before running the three scripts. Authenticated requests are limited per token, so what other tenants do on the shared IP no longer matters.

Set in the workflow rather than in the scripts, so the scripts still run locally without a token. Written inline in the three jobs rather than as a composite action like the e2e repo's: this repo has no `.github/actions/` directory, and three call sites in one file do not pay for one.

## Risks

- The rewrite is global for the rest of the job, so every later `github.com` clone in that job is authenticated too. That is intended; no step depends on being anonymous.
- The token is written to the runner's `~/.gitconfig`. Runners are ephemeral and the token expires when the job ends. `git config` prints nothing, so the token does not reach the logs.
- `GITHUB_TOKEN` is scoped to this repository but can read other public repos, and `multi-tenancy-load-test` is public. `tests.yaml` is `workflow_call`-only, reached from `matrix.yaml` (`workflow_dispatch` and `schedule`), so there is no fork-PR token path.

## Verification

The rewrite produces a working clone of the submodule target:

```
git -c url."https://x-access-token:$TOKEN@github.com/".insteadOf="https://github.com/" \
  clone https://github.com/weaviate/multi-tenancy-load-test
```

`tests.yaml` parses. The real check is a dispatched run of one of the three jobs.
