### PR TITLE
ci: free disk space before every chaos test job

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: 'Free Disk Space'
+description: 'Removes the preinstalled Android and .NET SDKs, which the runner image ships but these tests never use'
+
+runs:
+  using: composite
+  steps:
+    - uses: insightsengineering/disk-space-reclaimer@v1
+      with:
+        # Android and .NET are ~16 GB of the image and unused here; the rest is left alone (tools-cache holds Python).
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false
+        docker-images: false
+        swap-storage: false
+        tools-cache: false

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -272,6 +272,7 @@ jobs:
     runs-on: ubicloud-standard-2
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -300,6 +301,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -338,6 +340,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -377,6 +380,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -417,6 +421,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -456,6 +461,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -496,6 +502,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -537,6 +544,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -584,6 +592,7 @@ jobs:
       BOOT_DISK_SIZE: 50GB
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -622,6 +631,7 @@ jobs:
       QUANTIZATION: pq
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -662,6 +672,7 @@ jobs:
       QUANTIZATION: rq
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -711,6 +722,7 @@ jobs:
       MULTIVECTOR_DATASET: true
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -751,6 +763,7 @@ jobs:
       QUANTIZATION: pq
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -791,6 +804,7 @@ jobs:
       QUANTIZATION: sq
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -831,6 +845,7 @@ jobs:
       QUANTIZATION: rq
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -879,6 +894,7 @@ jobs:
       MULTIVECTOR_IMPLEMENTATION: muvera
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -930,6 +946,7 @@ jobs:
       MULTIVECTOR_IMPLEMENTATION: muvera
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -975,6 +992,7 @@ jobs:
       MULTIVECTOR_IMPLEMENTATION: muvera
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -1020,6 +1038,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1046,6 +1065,7 @@ jobs:
       ASYNC_INDEXING: ${{ inputs.async_indexing || 'true' }}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1077,6 +1097,7 @@ jobs:
       MINIMUM_WEAVIATE_VERSION: 1.22.0
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1106,6 +1127,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1131,6 +1153,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1154,6 +1177,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1177,6 +1201,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1200,6 +1225,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1223,6 +1249,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1246,6 +1273,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1269,6 +1297,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1292,6 +1321,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1315,6 +1345,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1338,6 +1369,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1361,6 +1393,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -1379,6 +1412,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1403,6 +1437,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -1421,6 +1456,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1444,6 +1480,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1467,6 +1504,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1490,6 +1528,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1513,6 +1552,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1536,6 +1576,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1560,6 +1601,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -1579,6 +1621,7 @@ jobs:
       ASYNC_INDEXING: 'false' # This test is not compatible with async indexing
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1602,6 +1645,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1625,6 +1669,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1648,6 +1693,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1672,6 +1718,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1696,6 +1743,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1719,6 +1767,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1742,6 +1791,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1766,6 +1816,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1790,6 +1841,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -1833,6 +1885,7 @@ jobs:
       MINIMUM_WEAVIATE_VERSION: 1.25.0
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -1867,6 +1920,7 @@ jobs:
           ASYNC_INDEXING: false
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -1972,6 +2026,7 @@ jobs:
           ASYNC_INDEXING: false
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2089,6 +2144,7 @@ jobs:
           ASYNC_INDEXING: false
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2156,6 +2212,7 @@ jobs:
           ASYNC_INDEXING: ${{ inputs.async_indexing || 'true' }}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2360,6 +2417,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -2391,6 +2449,7 @@ jobs:
       REQUIRED_RECALL: "0.992"
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       # - name: Polar Signals Continuous Profiling
       #   uses: polarsignals/gh-actions-ps-profiling@v0.0.1
       #   with:
@@ -2415,6 +2474,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2439,6 +2499,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2463,6 +2524,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2489,6 +2551,7 @@ jobs:
       NUM_NODES: 1
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -2516,6 +2579,7 @@ jobs:
       NUM_NODES: 3
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -2542,6 +2606,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2567,6 +2632,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2592,6 +2658,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2622,6 +2689,7 @@ jobs:
           ASYNC_INDEXING: ${{ inputs.async_indexing }}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2649,6 +2717,7 @@ jobs:
       ASYNC_INDEXING: true
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2673,6 +2742,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2708,6 +2778,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2749,6 +2820,7 @@ jobs:
       PERSISTENCE_LSM_ACCESS_STRATEGY: ${{inputs.lsm_access_strategy}}
     steps:
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2803,6 +2875,7 @@ jobs:
       # - name: Collect Workflow Telemetry
       #   uses: catchpoint/workflow-telemetry-action@v2
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -2876,6 +2949,7 @@ jobs:
       # - name: Collect Workflow Telemetry
       #   uses: catchpoint/workflow-telemetry-action@v2
       - uses: actions/checkout@v5
+      - uses: ./.github/actions/free-disk-space
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Problem

`ubicloud-standard-2` runners have a ~67 GB disk, and the runner image already fills ~60 GB of it. Disk sits at **~89% before any test writes a byte**. Weaviate's default `DISK_USE_READONLY_PERCENTAGE` is 90, so shards flip to read-only as soon as a test imports data:

```
failed to create object: conflict "insert to multi vector index: insert doc id 195 ...
  failed to put vectors_hnsw_multivec_muvera_muvera_vectors into the bucket: store is read-only"
```

From the pod logs of a job on the same runner:

```
"msg":"disk usage currently at 89.37%, threshold set to 80.00%"                 07:10:33
"msg":"Set READONLY, disk usage currently at 90.00%, threshold set to 90.00%"   07:15:02
```

This is not one test. Nine jobs failed this way in a single run: `alter-schema-drop-vector-index`, `rbac-upgrade-journey`, `upgrade-journey-raft` (both variants), `module-conflicting-vectorizer-settings`. The doc id and target vector differ each time, which fits a threshold crossed mid-import rather than a deterministic bug.

## Why it started

Ubicloud released image `ubuntu24/20260901.1` on Sep 1. Every passing run I checked ran on `20260801.1`; every failing run runs on `20260901.1`.

| Run | Image | Result |
|---|---|---|
| Aug 31 nightly | `20260801.1` | pass |
| Sep 2 15:48 | `20260801.1` | pass |
| Sep 3 nightly (main) | `20260901.1` | fail |

The image content is the same across runner tiers; only the disk size differs. `ubicloud-standard-4` sits at 42% used on a 145 GB disk, so it never trips. `ubicloud-standard-2` gets the same ~60 GB of preinstalled software on a ~67 GB disk.

## Change

Remove the preinstalled Android and .NET SDKs at the start of every job that starts Weaviate. Measured on an Ubicloud runner:

```
=> Android library: Saved 11GiB
=> .NET runtime:    Saved 5.4GiB
=> Haskell runtime: Saved 0B
```

~16 GB freed in **27 seconds**. That takes a `standard-2` job from ~89% to roughly 65%, with headroom for the ~5 GB a test writes.

This is the same `insightsengineering/disk-space-reclaimer@v1` step `weaviate-e2e-tests` already runs in 9 workflows, with the same inputs. It is wrapped in `.github/actions/free-disk-space` rather than pasted inline, because there are 74 call sites here — inline would have added ~660 lines instead of 74.

The step goes immediately after `actions/checkout`, before Docker login and before any cluster setup.

## What is not touched

`docker-images`, `large-packages`, `swap-storage` and `tools-cache` stay `false`, matching e2e. `tools-cache` holds the Python the tests need.

The 17 version-check and lint jobs get nothing — they never start Weaviate.

## Risks

- Adds ~27s to each of 74 jobs. They run in parallel, so wall-clock cost per run is one step, not 74.
- If a future test ever needs the .NET or Android SDK it would have to opt out. Nothing uses them today.
- No test behaviour changes; this only alters the runner's starting disk state.

## Verification

Not yet run in CI — a dispatched run is the real check. The freed-space and duration numbers above are read from a live Ubicloud job log, not estimated.

Note: this branch is cut from `main`, so it may need a trivial rebase if #441 lands first. Both touch `tests.yaml` but in different places.
