### PR TITLE
fix: bump remaining slim-bullseye base images to slim-bookworm

### DIFF
--- a/apps/backup-and-flush/Dockerfile
+++ b/apps/backup-and-flush/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/backup_and_restore_crud/Dockerfile
+++ b/apps/backup_and_restore_crud/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/backup_and_restore_node_mapping/Dockerfile
+++ b/apps/backup_and_restore_node_mapping/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/backup_and_restore_out_of_sync/Dockerfile
+++ b/apps/backup_and_restore_out_of_sync/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/backup_and_restore_version_compatibility/Dockerfile
+++ b/apps/backup_and_restore_version_compatibility/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/batch-import-many-classes/Dockerfile
+++ b/apps/batch-import-many-classes/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/batch-insert-mismatch/Dockerfile
+++ b/apps/batch-insert-mismatch/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/compaction-roaringset/Dockerfile
+++ b/apps/compaction-roaringset/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/compare-rest-graphql/Dockerfile
+++ b/apps/compare-rest-graphql/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/consecutive_create_and_update_operations/Dockerfile
+++ b/apps/consecutive_create_and_update_operations/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/delete_and_recreate/Dockerfile
+++ b/apps/delete_and_recreate/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/filter-memory-leak/Dockerfile
+++ b/apps/filter-memory-leak/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/geo-crash/Dockerfile
+++ b/apps/geo-crash/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/goroutine-leak-on-class-delete/Dockerfile
+++ b/apps/goroutine-leak-on-class-delete/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/namespace-graduation/Dockerfile
+++ b/apps/namespace-graduation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bullseye
+FROM python:3.13-slim-bookworm
 
 WORKDIR /workdir
 ENV PYTHONUNBUFFERED=1

--- a/apps/recall/Dockerfile
+++ b/apps/recall/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/replicated_import_with_backup/Dockerfile
+++ b/apps/replicated_import_with_backup/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/rest-patch-stops-working-after-restart/Dockerfile
+++ b/apps/rest-patch-stops-working-after-restart/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/segfault-on-batch-ref/Dockerfile
+++ b/apps/segfault-on-batch-ref/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/segfault-on-filtered-vector-search/Dockerfile
+++ b/apps/segfault-on-filtered-vector-search/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 

--- a/apps/telemetry-sink/Dockerfile
+++ b/apps/telemetry-sink/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 WORKDIR /workdir
 


### PR DESCRIPTION
Follow-up to #443, which bumped only the four Dockerfiles that run `apt-get` (the ones failing builds against EOL bullseye repos). The other 21 `python:*-slim-bullseye` images still build because they only run `pip install`, but bullseye no longer receives security updates.

This bumps all remaining `slim-bullseye` tags to `slim-bookworm`, keeping each image's Python version (3.10/3.11/3.13). Only the `FROM` lines change; none of these images install OS packages, so there is nothing bullseye-specific to migrate. All three target tags verified to exist on Docker Hub.